### PR TITLE
Recut the catalog rail onto columns 1–2 below 1440

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,9 @@ jobs:
           grep -q 'rasterCategories' "$nav"
           grep -q 'data-toc="groups"' "$nav"
           grep -q 'data-toc="items"' "$nav"
+          grep -q 'data-rail="catalog"' "$nav"
+          grep -q 'max-width: 1439px' apps/www/components/docs-nav/docs-nav.css
+          grep -q '1440' "$map"
           if grep -n toc-rail apps/www/app/site.css; then
             echo "Docs-rail styles drifted back into site chrome"
             exit 1

--- a/apps/www/app/site.css
+++ b/apps/www/app/site.css
@@ -6,6 +6,8 @@
    - The content column starts one module in (margin-left: 204px at
      the 1024px rail) and the layout width rounds DOWN to whole 204px
      modules, so edges step from grid line to grid line on resize.
+     The catalog rail drops that inset below 1440 (writer in docs-nav)
+     so the two navs sit in columns 1 and 2 on a narrow desktop.
    - Reading measure is 592px (3 modules); covers pad 120px down.
    - A fixed 72px crumb bar; breadcrumbs fade in once the page cover
      scrolls away. The docs rail lives in components/docs-nav. */

--- a/apps/www/components/docs-nav/FEATURE.md
+++ b/apps/www/components/docs-nav/FEATURE.md
@@ -7,7 +7,7 @@ Writers: catalog groups are `packages/core/src/schema.ts` (`rasterCategories`). 
 | Surface | Route | Click path | Done |
 | --- | --- | --- | --- |
 | Specimen | `/` | Logo, or the site root | Full-viewport 204 poster. Top and left flush — no outer frame. Hero word is Raster, set in Inter. Law is “A poster you can install.” One command. Internal hairlines stay. |
-| Components index | `/components` | Corner → Components | First column is catalog groups from `rasterCategories`. Hover Navigation or Feedback; second column is that group's items. Secondaries are paper: no left border, no inset 184-line. The 408 module line is the only join. Catalog tiles are opaque paper (`isolation` + paper fill on the face and the description); the page grid stops at the card edge. |
+| Components index | `/components` | Corner → Components | First column is catalog groups from `rasterCategories`. Hover Navigation or Feedback; second column is that group's items. Secondaries are paper: no left border, no inset 184-line. The 408 module line is the only join. Below 1440 the rail occupies columns 1–2 (the 1024 inset drops). From 1440 the chrome keeps the one-module inset. Catalog tiles are opaque paper (`isolation` + paper fill on the face and the description); the page grid stops at the card edge. |
 | Component | `/components/:name` | Hover the group → click the item | That page's group stays selected. Column two is not empty. |
 | Getting started | `/docs` | Corner → Docs | Short rail: Getting started, Tokens. Command is the one in `app/specimen.ts`. |
 | Tokens | `/docs/tokens` | Docs → Tokens | Same short rail. |

--- a/apps/www/components/docs-nav/docs-nav.css
+++ b/apps/www/components/docs-nav/docs-nav.css
@@ -11,6 +11,23 @@
   gap: 0;
 }
 @media (min-width: 900px) { .toc-rail { display: flex; } }
+
+/* Below the 1440 wide anchor, cancel the chrome's one-module inset
+   so groups sit in column 1 and secondaries in column 2. Content
+   stays in flow after those two modules. Wide desktop keeps the
+   airy 1024 placement. No hamburger — the rail is already hidden
+   under 900, and the existing burger is site chrome only. */
+@media (min-width: 1024px) and (max-width: 1439px) {
+  .site-layout:has([data-rail="catalog"]) {
+    --ml: 0px;
+    margin-left: 0;
+  }
+  body:has([data-rail="catalog"]) .rs-crumb-bar-inner {
+    margin-left: 0;
+    padding-left: 76px;
+  }
+}
+
 .toc {
   width: 184px; flex-shrink: 0;
   height: 100%; overflow-y: auto;

--- a/apps/www/components/docs-nav/index.tsx
+++ b/apps/www/components/docs-nav/index.tsx
@@ -28,6 +28,8 @@ const groups = rasterCategories.filter((category) =>
  * Components rail: groups in the first 184, that group's items in the
  * second. Hover (and focus) fills the second column. The page's own
  * group stays selected so the column is never empty on load.
+ * Below 1440 the rail occupies columns 1–2; from 1440 the chrome
+ * keeps the one-module inset.
  */
 export function DocsNav() {
   const pathname = usePathname();
@@ -67,7 +69,7 @@ export function DocsNav() {
   const items = shown ? rasterComponents.filter((c) => c.category === shown) : [];
 
   return (
-    <div className="toc-rail" onPointerLeave={leaveRail} onBlur={leaveRail}>
+    <div className="toc-rail" data-rail="catalog" onPointerLeave={leaveRail} onBlur={leaveRail}>
       <nav className="toc" data-toc="groups" aria-label="Component groups">
         {groups.map((category) => (
           <Link


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The 1024 one-module inset is locked for wide chrome. On a narrower desktop it pushed the two catalog navs past the first columns and left those modules empty.

**Breakpoint.** `1440` is already the `wide` token (`rasterTokens.breakpoints.wide` / `grid.anchors.wide`). Seven 204 modules fit there, so the airy inset can stay. From 1024–1439 only five or six modules fit, and that is where the waste shows. The rail already appears at 900 and is already compact in the 900–1023 band (no inset). No new hamburger: the existing burger is site chrome at 640; the rail stays hidden under 900.

**What changes**
- Catalog rail (`data-rail="catalog"`) drops the 204px site-layout inset below 1440 so groups sit in column 1 and secondaries in column 2.
- Content stays in flow after those two modules. The lists are not merged.
- Hover still fills column two of the rail. Secondaries stay paper: gridlines only, no extra left border.
- Crumb inner follows the same compact cut so “Raster” does not slide onto the secondaries column.
- Wide (≥1440) keeps the current one-module inset.

Docs/tokens keep the short rail and the 1024 inset. No npm publish. Do not merge.

Informed by Renato’s ask on the catalog rail after the 0.3 merge. Granola was not available in this run.

**Verify**
- CI `test` green on this head.
- Local `/components` at 1100 and 1439: groups `x=20` (column 1), secondaries `x=205` (column 2), content `x=409` (after the rail, no overlap). Burger `display: none`.
- Same page at 1440 and 1600: groups `x=224`, secondaries `x=409` — the locked airy inset.
- `/components/button` at 1100 uses the same compact rail. `/docs` at 1100 keeps the 1024 inset (short rail, not catalog).
- Hover Navigation fills column two with Tabs / Breadcrumbs / …

Narrow (1100), groups in column 1, secondaries in column 2:

[Catalog rail at 1100, groups in column 1 and secondaries in column 2](https://cursor.com/agents/bc-7d6fa293-66cc-422e-93ef-053fa86a78da/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcatalog-narrow-1100.png)

Wide (1600), airy inset kept:

[Catalog rail at 1600, one-module inset kept](https://cursor.com/agents/bc-7d6fa293-66cc-422e-93ef-053fa86a78da/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcatalog-wide-1600.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d6fa293-66cc-422e-93ef-053fa86a78da?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d6fa293-66cc-422e-93ef-053fa86a78da&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

