### PR TITLE
Add Interfaces: six Raster prototype posters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,33 @@ jobs:
             echo "Masthead must not grow a left rule"
             exit 1
           fi
+      - name: Interfaces is six posters
+        run: |
+          node apps/www/scripts/check-interfaces.mjs
+          grep -q 'href: "/interfaces"' apps/www/components/site-chrome.tsx
+          grep -q 'label: "Interfaces"' apps/www/components/site-chrome.tsx
+          test -f apps/www/app/interfaces/FEATURE.md
+          test -f apps/www/app/interfaces/catalog.ts
+          test -f apps/www/app/interfaces/page.tsx
+          test -f apps/www/app/interfaces/interfaces.css
+          for slug in ai-tool dashboard threads fleet delivery slack; do
+            test -f "apps/www/app/interfaces/$slug/page.tsx"
+            test -f "apps/www/app/interfaces/$slug/board.tsx"
+          done
+          test -f apps/www/app/interfaces/fleet/map.tsx
+          grep -q 'Working posters. The catalog, composed.' apps/www/app/interfaces/page.tsx
+          if grep -R -n -E 'tailwind|@radix-ui' apps/www/app/interfaces; then
+            echo "Interfaces must stay off Tailwind and Radix"
+            exit 1
+          fi
+          if grep -n 'box-shadow:' apps/www/app/interfaces/interfaces.css | grep -v 'none'; then
+            echo "Interfaces chrome must not grow a shadow"
+            exit 1
+          fi
+          if grep -n about.css apps/www/app/site.css || grep -n interfaces.css apps/www/app/site.css; then
+            echo "Interfaces styles must stay isolated"
+            exit 1
+          fi
       - name: Components TOC is catalog groups
         run: |
           nav=apps/www/components/docs-nav/index.tsx

--- a/apps/www/app/interfaces/FEATURE.md
+++ b/apps/www/app/interfaces/FEATURE.md
@@ -1,0 +1,19 @@
+# Interfaces
+
+What it is, how to get there, what done looks like.
+
+Writers: the six live in `app/interfaces/catalog.ts`. Each proto is its own folder and its own route. The section is a first-class nav sibling of Components, Docs, and About — not a page inside a component. Compose the Raster catalog. Do not invent a second kit.
+
+Chrome stays monochrome. A board may set one Crouwel spot or a color-field. Inter, 204 module, hairlines, flush, no radius, no shadow, sentence case.
+
+| Surface | Route | Click path | Done |
+| --- | --- | --- | --- |
+| Interfaces index | `/interfaces` | Corner → Interfaces | Lists the six. First column is the six. Each tile is a proto. |
+| AI tool | `/interfaces/ai-tool` | Interfaces → AI tool | Sidebar, main canvas, AI chat box, in-feed widgets. |
+| SaaS dashboard | `/interfaces/dashboard` | Interfaces → SaaS dashboard | Sidebar, graphs, lists, multiple panes. |
+| Threads | `/interfaces/threads` | Interfaces → Threads | Main feed, content types, threads, discussion. |
+| Fleet | `/interfaces/fleet` | Interfaces → Fleet | Floating Raster on a three.js map. Active fleet, inactive objects, alerts. Map is a scene, not the noord.vc marketing page. |
+| Food delivery | `/interfaces/delivery` | Interfaces → Food delivery | Main browsing, navbar, ratings. |
+| Slack | `/interfaces/slack` | Interfaces → Slack | Chat UI, sidebar, agents mixed with real people. |
+
+The six folders are `ai-tool`, `dashboard`, `threads`, `fleet`, `delivery`, `slack`. CI fails if any route disappears.

--- a/apps/www/app/interfaces/ai-tool/board.tsx
+++ b/apps/www/app/interfaces/ai-tool/board.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import * as React from "react";
+import {
+  Badge,
+  Button,
+  ButtonGroup,
+  ScrollArea,
+  Sidebar,
+  SidebarFoot,
+  SidebarHead,
+  SidebarItem,
+  SidebarLabel,
+  SidebarNav,
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
+  Textarea,
+} from "@noordvc/raster-react";
+
+const SHEETS = [
+  { href: "#brief", label: "Brief", current: true },
+  { href: "#press", label: "Press run" },
+  { href: "#invoice", label: "Invoice note" },
+];
+
+export function Board() {
+  const [tab, setTab] = React.useState("brief");
+  const [note, setNote] = React.useState("Cut the opening. Keep the fee on the first page.");
+
+  return (
+    <main className="if-board" aria-label="AI tool">
+      <div className="if-app">
+        <Sidebar>
+          <SidebarHead>Sheet</SidebarHead>
+          <SidebarNav>
+            <SidebarLabel>Open</SidebarLabel>
+            {SHEETS.map((item) => (
+              <SidebarItem key={item.href} href={item.href} current={item.current}>
+                {item.label}
+              </SidebarItem>
+            ))}
+            <SidebarLabel>Library</SidebarLabel>
+            <SidebarItem href="#proofs">Proofs</SidebarItem>
+            <SidebarItem href="#refs">References</SidebarItem>
+          </SidebarNav>
+          <SidebarFoot>Local · 3 sheets</SidebarFoot>
+        </Sidebar>
+
+        <section className="if-main" aria-label="Canvas">
+          <div className="if-head">
+            <p className="if-head-title">Brief</p>
+            <ButtonGroup>
+              <Button variant="ghost" size="sm">
+                Write
+              </Button>
+              <Button variant="ghost" size="sm">
+                Review
+              </Button>
+            </ButtonGroup>
+          </div>
+          <div className="if-pane">
+            <Tabs value={tab} onValueChange={setTab}>
+              <TabList>
+                <Tab value="brief">Brief</Tab>
+                <Tab value="notes">Notes</Tab>
+              </TabList>
+              <TabPanel value="brief">
+                <div className="if-stack" style={{ marginTop: 20 }}>
+                  <div className="if-sheet">
+                    <p className="if-kicker">Page 1</p>
+                    <p className="if-copy">
+                      One sheet. Scope, weeks, and the fee. The number on the cover is the number on
+                      the invoice.
+                    </p>
+                    <p className="if-copy" style={{ marginTop: 12 }}>
+                      Press starts week 4. Proofs stay in the same ink. No second color in the chrome.
+                    </p>
+                  </div>
+                  <article className="rs-ai-card">
+                    <span className="rs-ai-tag">Widget</span>
+                    <p className="rs-ai-text">Move the timeline under the fee. Two lines, not a list.</p>
+                    <p className="rs-ai-done">
+                      <svg viewBox="0 0 16 16" width="14" height="14" fill="none" aria-hidden="true">
+                        <path d="M3 8.5 6.5 12 13 4.5" stroke="currentColor" strokeWidth="1.5" />
+                      </svg>
+                      Applied to the brief
+                    </p>
+                  </article>
+                  <article className="rs-ai-card">
+                    <span className="rs-ai-tag">Widget</span>
+                    <p className="rs-ai-text">The refs hang in the gutter. Keep the cite box after the claim.</p>
+                    <div style={{ marginTop: 12 }}>
+                      <Button variant="ghost" size="sm">
+                        Apply
+                      </Button>
+                    </div>
+                  </article>
+                </div>
+              </TabPanel>
+              <TabPanel value="notes">
+                <div style={{ marginTop: 20 }}>
+                  <Textarea
+                    label="Scratch"
+                    value={note}
+                    onChange={(e) => setNote(e.target.value)}
+                  />
+                </div>
+              </TabPanel>
+            </Tabs>
+          </div>
+        </section>
+
+        <aside className="if-col" aria-label="AI chat">
+          <div className="if-head">
+            <p className="if-head-title">Assistant</p>
+            <Badge variant="muted">On the sheet</Badge>
+          </div>
+          <ScrollArea maxHeight="none" style={{ flex: 1, maxHeight: "none" }}>
+            <div className="rs-ai" style={{ border: "none", padding: 20 }}>
+              <div className="rs-ai-head">
+                <p className="rs-ai-title">Sheet</p>
+                <p className="rs-ai-status">
+                  <i />
+                  Reading brief
+                </p>
+              </div>
+              <div className="rs-ai-msg rs-ai-user">
+                <div className="rs-ai-user-block">Make the intro tighter.</div>
+              </div>
+              <p className="rs-ai-reply">
+                Two sentences, same claim. The fee stays on the first page; the weeks follow it.
+              </p>
+              <div className="rs-ai-msg rs-ai-user">
+                <div className="rs-ai-user-block">Show the edit as a widget in the canvas.</div>
+              </div>
+              <p className="rs-ai-reply">Applied. The timeline sits under the fee now.</p>
+              <article className="rs-ai-card">
+                <span className="rs-ai-tag">In feed</span>
+                <p className="rs-ai-text">Next: hang the Müller-Brockmann cite on the grid claim.</p>
+              </article>
+            </div>
+          </ScrollArea>
+          <div className="if-composer">
+            <div className="rs-ai-input">
+              <span>Ask the sheet…</span>
+              <span className="rs-ai-send">Send</span>
+            </div>
+          </div>
+        </aside>
+      </div>
+    </main>
+  );
+}

--- a/apps/www/app/interfaces/ai-tool/page.tsx
+++ b/apps/www/app/interfaces/ai-tool/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import { interfaceBySlug } from "../catalog";
+import "../interfaces.css";
+import { Board } from "./board";
+
+const proto = interfaceBySlug("ai-tool")!;
+
+export const metadata: Metadata = {
+  title: proto.title,
+  description: proto.law,
+};
+
+export default function Page() {
+  return <Board />;
+}

--- a/apps/www/app/interfaces/catalog.ts
+++ b/apps/www/app/interfaces/catalog.ts
@@ -1,0 +1,40 @@
+export const interfaces = [
+  {
+    slug: "ai-tool",
+    title: "AI tool",
+    law: "Sidebar, main canvas, chat box, in-feed widgets.",
+  },
+  {
+    slug: "dashboard",
+    title: "SaaS dashboard",
+    law: "Sidebar, graphs, lists, multiple panes.",
+  },
+  {
+    slug: "threads",
+    title: "Threads",
+    law: "Main feed, content types, threads, discussion.",
+  },
+  {
+    slug: "fleet",
+    title: "Fleet",
+    law: "Floating Raster on a three.js map. Active, inactive, alerts.",
+  },
+  {
+    slug: "delivery",
+    title: "Food delivery",
+    law: "Main browsing, navbar, ratings.",
+  },
+  {
+    slug: "slack",
+    title: "Slack",
+    law: "Chat, sidebar, agents mixed with people.",
+  },
+] as const;
+
+export type InterfaceSlug = (typeof interfaces)[number]["slug"];
+
+export const INTERFACE_SLUGS = interfaces.map((item) => item.slug);
+
+export function interfaceBySlug(slug: string) {
+  return interfaces.find((item) => item.slug === slug);
+}

--- a/apps/www/app/interfaces/dashboard/board.tsx
+++ b/apps/www/app/interfaces/dashboard/board.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import * as React from "react";
+import {
+  Badge,
+  BarChart,
+  DataTable,
+  Donut,
+  Item,
+  LineChart,
+  ScrollArea,
+  Sidebar,
+  SidebarFoot,
+  SidebarHead,
+  SidebarItem,
+  SidebarLabel,
+  SidebarNav,
+  Split,
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
+  ToggleGroup,
+} from "@noordvc/raster-react";
+
+const DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const SHEETS = [12, 18, 15, 26, 24, 11, 9];
+const PROOFS = [4, 6, 5, 9, 7, 3, 2];
+
+const ROWS = [
+  { job: "Press run 14", city: "Alkmaar", weeks: 4, state: "On press" },
+  { job: "Identity 09", city: "Delft", weeks: 6, state: "Proof" },
+  { job: "Ledger 03", city: "Haarlem", weeks: 2, state: "Invoice" },
+  { job: "Poster 22", city: "Utrecht", weeks: 3, state: "Brief" },
+];
+
+export function Board() {
+  const [range, setRange] = React.useState("week");
+  const [tab, setTab] = React.useState("overview");
+
+  return (
+    <main className="if-board" aria-label="SaaS dashboard">
+      <div className="if-app">
+        <Sidebar>
+          <SidebarHead>Ledger</SidebarHead>
+          <SidebarNav>
+            <SidebarLabel>Studio</SidebarLabel>
+            <SidebarItem href="#overview" current>
+              Overview
+            </SidebarItem>
+            <SidebarItem href="#jobs">Jobs</SidebarItem>
+            <SidebarItem href="#invoices">Invoices</SidebarItem>
+            <SidebarLabel>Field</SidebarLabel>
+            <SidebarItem href="#press">Press</SidebarItem>
+            <SidebarItem href="#proofs">Proofs</SidebarItem>
+          </SidebarNav>
+          <SidebarFoot>Week 34</SidebarFoot>
+        </Sidebar>
+
+        <section className="if-main" aria-label="Dashboard">
+          <div className="if-head">
+            <p className="if-head-title">Overview</p>
+            <ToggleGroup
+              value={range}
+              onValueChange={setRange}
+              options={[
+                { value: "week", label: "Week" },
+                { value: "month", label: "Month" },
+              ]}
+            />
+          </div>
+          <div className="if-pane">
+            <Tabs value={tab} onValueChange={setTab}>
+              <TabList>
+                <Tab value="overview">Overview</Tab>
+                <Tab value="jobs">Jobs</Tab>
+              </TabList>
+              <TabPanel value="overview">
+                <div className="if-stack" style={{ marginTop: 20 }}>
+                  <Split initial={62} min={40} max={75}>
+                    <div className="if-stack">
+                      <p className="if-kicker">Sheets this {range}</p>
+                      <LineChart
+                        height={204}
+                        labels={DAYS}
+                        series={[
+                          { name: "Sheets", values: SHEETS },
+                          { name: "Proofs", values: PROOFS },
+                        ]}
+                        unit="sheets"
+                        annotations={[{ at: 3, label: "Press" }]}
+                        spot
+                      />
+                      <BarChart
+                        height={184}
+                        orientation="horizontal"
+                        data={[
+                          { label: "Alkmaar", value: 42 },
+                          { label: "Delft", value: 28 },
+                          { label: "Haarlem", value: 21 },
+                          { label: "Utrecht", value: 16 },
+                        ]}
+                        unit="jobs"
+                      />
+                    </div>
+                    <div className="if-stack">
+                      <p className="if-kicker">Share</p>
+                      <Donut value={72} max={100} size={184} label="printed" />
+                      <ScrollArea maxHeight={204}>
+                        <Item title="Press run 14" description="Alkmaar · four weeks" meta={<Badge variant="solid">On press</Badge>} />
+                        <Item title="Identity 09" description="Delft · proofs due" meta={<Badge variant="muted">Proof</Badge>} />
+                        <Item title="Ledger 03" description="Haarlem · invoice out" meta={<Badge>Invoice</Badge>} />
+                        <Item title="Poster 22" description="Utrecht · brief open" meta={<Badge variant="muted">Brief</Badge>} />
+                      </ScrollArea>
+                    </div>
+                  </Split>
+                </div>
+              </TabPanel>
+              <TabPanel value="jobs">
+                <div style={{ marginTop: 20 }}>
+                  <DataTable
+                    columns={[
+                      { key: "job", header: "Job", sortable: true },
+                      { key: "city", header: "City", sortable: true },
+                      { key: "weeks", header: "Weeks", sortable: true },
+                      { key: "state", header: "State" },
+                    ]}
+                    rows={ROWS}
+                  />
+                </div>
+              </TabPanel>
+            </Tabs>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/www/app/interfaces/dashboard/page.tsx
+++ b/apps/www/app/interfaces/dashboard/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import { interfaceBySlug } from "../catalog";
+import "../interfaces.css";
+import { Board } from "./board";
+
+const proto = interfaceBySlug("dashboard")!;
+
+export const metadata: Metadata = {
+  title: proto.title,
+  description: proto.law,
+};
+
+export default function Page() {
+  return <Board />;
+}

--- a/apps/www/app/interfaces/delivery/board.tsx
+++ b/apps/www/app/interfaces/delivery/board.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import * as React from "react";
+import {
+  Badge,
+  Button,
+  Card,
+  CardBody,
+  CardLabel,
+  CardTitle,
+  Carousel,
+  Input,
+  Item,
+  NavigationMenu,
+  ToggleGroup,
+} from "@noordvc/raster-react";
+
+const PLACES = [
+  { name: "De Buren", kind: "Kitchen", rating: "4.8", time: "22 min", area: "Alkmaar", tag: "Open" },
+  { name: "Kaasbar", kind: "Counter", rating: "4.6", time: "18 min", area: "Kaasmarkt", tag: "Busy" },
+  { name: "Canal kitchen", kind: "Kitchen", rating: "4.7", time: "27 min", area: "Oudegracht", tag: "Open" },
+  { name: "Press lunch", kind: "Counter", rating: "4.4", time: "14 min", area: "Spoor", tag: "Open" },
+  { name: "North plate", kind: "Kitchen", rating: "4.9", time: "31 min", area: "Beverkoog", tag: "Later" },
+  { name: "Sheet bakery", kind: "Bakery", rating: "4.5", time: "16 min", area: "Centrum", tag: "Open" },
+];
+
+export function Board() {
+  const [filter, setFilter] = React.useState("all");
+  const shown = PLACES.filter((p) => filter === "all" || p.kind.toLowerCase() === filter);
+
+  return (
+    <main className="if-board" aria-label="Food delivery">
+      <div className="if-app" style={{ flexDirection: "column" }}>
+        <header className="if-head" style={{ paddingLeft: 20, paddingRight: 20 }}>
+          <p className="if-head-title">Alkmaar</p>
+          <NavigationMenu
+            items={[
+              { label: "Browse", href: "#browse", current: true },
+              { label: "Orders", href: "#orders" },
+              { label: "Account", href: "#account" },
+            ]}
+          />
+          <Badge variant="solid">Open</Badge>
+        </header>
+
+        <div className="if-pane">
+          <div className="if-stack">
+            <Input label="Search" placeholder="Kitchen, street, dish" />
+            <ToggleGroup
+              value={filter}
+              onValueChange={setFilter}
+              options={[
+                { value: "all", label: "All" },
+                { value: "kitchen", label: "Kitchen" },
+                { value: "counter", label: "Counter" },
+                { value: "bakery", label: "Bakery" },
+              ]}
+            />
+            <div>
+              <p className="if-kicker">Tonight</p>
+              <Carousel aria-label="Places">
+                {PLACES.slice(0, 4).map((place) => (
+                  <Card key={place.name} style={{ width: 184 }}>
+                    <CardLabel>{place.kind}</CardLabel>
+                    <CardTitle>{place.name}</CardTitle>
+                    <CardBody>
+                      {place.rating} · {place.time}
+                    </CardBody>
+                  </Card>
+                ))}
+              </Carousel>
+            </div>
+            <div className="if-grid-2">
+              {shown.map((place) => (
+                <article key={place.name} className="if-sheet">
+                  <div style={{ display: "flex", justifyContent: "space-between", gap: 12 }}>
+                    <p className="if-kicker" style={{ margin: 0 }}>
+                      {place.area}
+                    </p>
+                    <Badge variant={place.tag === "Open" ? "solid" : place.tag === "Busy" ? "outline" : "muted"}>
+                      {place.tag}
+                    </Badge>
+                  </div>
+                  <h2 className="rs-card-title" style={{ marginTop: 8 }}>
+                    {place.name}
+                  </h2>
+                  <Item title={`${place.rating} rating`} description={place.kind} meta={place.time} />
+                  <Button variant="ghost" size="sm">
+                    Open menu
+                  </Button>
+                </article>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/www/app/interfaces/delivery/page.tsx
+++ b/apps/www/app/interfaces/delivery/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import { interfaceBySlug } from "../catalog";
+import "../interfaces.css";
+import { Board } from "./board";
+
+const proto = interfaceBySlug("delivery")!;
+
+export const metadata: Metadata = {
+  title: proto.title,
+  description: proto.law,
+};
+
+export default function Page() {
+  return <Board />;
+}

--- a/apps/www/app/interfaces/fleet/board.tsx
+++ b/apps/www/app/interfaces/fleet/board.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import * as React from "react";
+import {
+  Alert,
+  Badge,
+  Item,
+  ScrollArea,
+} from "@noordvc/raster-react";
+import { FleetMap } from "./map";
+
+const ACTIVE = [
+  { id: "Van 04", where: "Kennemerstraatweg", meta: "En route" },
+  { id: "Van 11", where: "Spoorbrug", meta: "En route" },
+  { id: "Bike 08", where: "Kaasmarkt", meta: "Pickup" },
+  { id: "Boat 02", where: "Oudegracht", meta: "Hold" },
+];
+
+const INACTIVE = [
+  { id: "Van 19", where: "Yard north", meta: "Parked" },
+  { id: "Van 03", where: "Yard north", meta: "Service" },
+  { id: "Bike 14", where: "Spoor", meta: "Parked" },
+  { id: "Boat 06", where: "Haven", meta: "Idle" },
+  { id: "Van 22", where: "Beverkoog", meta: "Parked" },
+];
+
+export function Board() {
+  const [pick, setPick] = React.useState("Van 04");
+
+  return (
+    <main className="if-board if-fleet" aria-label="Fleet">
+      <FleetMap />
+      <section className="if-float if-float-a" aria-label="Active fleet">
+        <p className="if-kicker">Active fleet</p>
+        <ScrollArea maxHeight={280}>
+          {ACTIVE.map((unit) => (
+            <Item
+              key={unit.id}
+              title={unit.id}
+              description={unit.where}
+              meta={
+                <Badge variant={unit.id === pick ? "solid" : "outline"}>{unit.meta}</Badge>
+              }
+              onClick={() => setPick(unit.id)}
+              style={{ cursor: "pointer" }}
+            />
+          ))}
+        </ScrollArea>
+      </section>
+      <section className="if-float if-float-b" aria-label="Inactive objects">
+        <p className="if-kicker">Inactive objects</p>
+        <ScrollArea maxHeight={280}>
+          {INACTIVE.map((unit) => (
+            <Item key={unit.id} title={unit.id} description={unit.where} meta={unit.meta} />
+          ))}
+        </ScrollArea>
+      </section>
+      <section className="if-float if-float-c" aria-label="Alerts">
+        <Alert title="Density drop on plate 09">
+          Boat 02 is holding on the Oudegracht. Van 11 is two minutes out.
+        </Alert>
+        <div
+          className="if-field-spot"
+          style={{ marginTop: 12, ["--rs-chart-spot" as string]: "#E30613" }}
+        >
+          <p className="if-kicker">Alert field</p>
+          <Item
+            title="Boat 02"
+            description="Hold · Oudegracht"
+            meta={<Badge variant="solid">Alert</Badge>}
+          />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/www/app/interfaces/fleet/map.tsx
+++ b/apps/www/app/interfaces/fleet/map.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import * as React from "react";
+import * as THREE from "three";
+import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+
+const SPOT = "#E30613";
+
+function readColor(name: string, fallback: string) {
+  const raw = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  return raw || fallback;
+}
+
+type Vehicle = {
+  mesh: THREE.Mesh;
+  path: THREE.Vector3[];
+  t: number;
+  speed: number;
+};
+
+function rectPath(cx: number, cz: number, w: number, d: number): THREE.Vector3[] {
+  return [
+    new THREE.Vector3(cx - w, 1.2, cz - d),
+    new THREE.Vector3(cx + w, 1.2, cz - d),
+    new THREE.Vector3(cx + w, 1.2, cz + d),
+    new THREE.Vector3(cx - w, 1.2, cz + d),
+  ];
+}
+
+function follow(path: THREE.Vector3[], t: number) {
+  const n = path.length;
+  const i = Math.floor(t) % n;
+  const n1 = (i + 1) % n;
+  const local = t - Math.floor(t);
+  const from = path[i]!;
+  const to = path[n1]!;
+  return {
+    position: from.clone().lerp(to, local),
+    yaw: Math.atan2(to.x - from.x, to.z - from.z),
+  };
+}
+
+export function FleetMap() {
+  const host = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    const el = host.current;
+    if (!el) return;
+
+    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(38, 1, 1, 9000);
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setClearColor(0, 0);
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    el.appendChild(renderer.domElement);
+
+    const ground = new THREE.Mesh(
+      new THREE.PlaneGeometry(2400, 2400),
+      new THREE.MeshBasicMaterial({ side: THREE.DoubleSide }),
+    );
+    ground.rotation.x = -Math.PI / 2;
+    scene.add(ground);
+
+    const grid = new THREE.GridHelper(1800, 36);
+    const gridMat = grid.material as THREE.LineBasicMaterial;
+    gridMat.transparent = true;
+    gridMat.opacity = 0.35;
+    scene.add(grid);
+
+    const buildingGeo = new THREE.BoxGeometry(1, 1, 1);
+    buildingGeo.translate(0, 0.5, 0);
+    const buildingMat = new THREE.MeshBasicMaterial();
+    const buildings = new THREE.InstancedMesh(buildingGeo, buildingMat, 86);
+    const dummy = new THREE.Object3D();
+    let placed = 0;
+    for (let x = -8; x <= 8; x++) {
+      for (let z = -8; z <= 8; z++) {
+        if (placed >= 86) break;
+        if ((x + z * 3) % 4 === 0) continue;
+        const h = 8 + ((Math.abs(x * 17 + z * 31) % 28) + 6);
+        dummy.position.set(x * 42, 0, z * 42);
+        dummy.scale.set(16 + (placed % 5), h, 14 + (placed % 4));
+        dummy.updateMatrix();
+        buildings.setMatrixAt(placed, dummy.matrix);
+        placed += 1;
+      }
+    }
+    buildings.count = placed;
+    scene.add(buildings);
+
+    const activeMat = new THREE.MeshBasicMaterial();
+    const inactiveMat = new THREE.MeshBasicMaterial({ transparent: true, opacity: 0.38 });
+    const alertMat = new THREE.MeshBasicMaterial();
+    const vanGeo = new THREE.BoxGeometry(6.2, 2.2, 3.1);
+    vanGeo.translate(0, 1.1, 0);
+
+    const actives: Vehicle[] = [
+      { mesh: new THREE.Mesh(vanGeo, activeMat), path: rectPath(-80, -40, 220, 140), t: 0.1, speed: 0.12 },
+      { mesh: new THREE.Mesh(vanGeo, activeMat), path: rectPath(40, 80, 180, 160), t: 1.4, speed: 0.09 },
+      { mesh: new THREE.Mesh(vanGeo, activeMat), path: rectPath(-20, 20, 260, 90), t: 2.2, speed: 0.11 },
+      { mesh: new THREE.Mesh(vanGeo, activeMat), path: rectPath(120, -90, 140, 200), t: 0.7, speed: 0.1 },
+    ];
+    for (const van of actives) scene.add(van.mesh);
+
+    const parked = [
+      new THREE.Vector3(-160, 0, 180),
+      new THREE.Vector3(-40, 0, 210),
+      new THREE.Vector3(90, 0, 200),
+      new THREE.Vector3(210, 0, 40),
+      new THREE.Vector3(-200, 0, -30),
+    ].map((pos) => {
+      const mesh = new THREE.Mesh(vanGeo, inactiveMat);
+      mesh.position.copy(pos);
+      mesh.position.y = 0;
+      scene.add(mesh);
+      return mesh;
+    });
+
+    const alertGeo = new THREE.CylinderGeometry(1.1, 1.1, 28, 8);
+    alertGeo.translate(0, 14, 0);
+    const alerts = [
+      new THREE.Vector3(80, 0, -60),
+      new THREE.Vector3(-120, 0, 90),
+    ].map((pos) => {
+      const mesh = new THREE.Mesh(alertGeo, alertMat);
+      mesh.position.copy(pos);
+      scene.add(mesh);
+      return mesh;
+    });
+
+    const paint = () => {
+      const paper = readColor("--bg", "#FAF8F2");
+      const ink = readColor("--text", "#1A1A1A");
+      const gray = readColor("--text-secondary", "#6B6B6B");
+      const line = readColor("--divider", "rgba(0,0,0,0.10)");
+      ground.material.color.set(paper);
+      buildingMat.color.set(paper).lerp(new THREE.Color(ink), 0.16);
+      gridMat.color.set(line);
+      activeMat.color.set(ink);
+      inactiveMat.color.set(gray);
+      alertMat.color.set(SPOT);
+      scene.fog = new THREE.Fog(new THREE.Color(paper), 900, 4200);
+      scene.background = new THREE.Color(paper);
+    };
+    paint();
+    const theme = new MutationObserver(paint);
+    theme.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
+
+    camera.position.set(420, 380, 520);
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.target.set(0, 0, 0);
+    controls.enableZoom = false;
+    controls.enablePan = false;
+    controls.enableDamping = true;
+    controls.dampingFactor = 0.06;
+    controls.minPolarAngle = 0.55;
+    controls.maxPolarAngle = 1.25;
+    controls.autoRotate = !reduced;
+    controls.autoRotateSpeed = 0.35;
+
+    const resize = () => {
+      const w = el.clientWidth;
+      const h = el.clientHeight;
+      camera.aspect = w / Math.max(1, h);
+      camera.updateProjectionMatrix();
+      renderer.setSize(w, h);
+    };
+    resize();
+    const ro = new ResizeObserver(resize);
+    ro.observe(el);
+
+    let frame = 0;
+    let last = performance.now();
+    const tick = () => {
+      frame = requestAnimationFrame(tick);
+      const now = performance.now();
+      const dt = Math.min((now - last) / 1000, 0.1);
+      last = now;
+      if (!reduced) {
+        for (const van of actives) {
+          van.t += van.speed * dt;
+          const pose = follow(van.path, van.t);
+          van.mesh.position.copy(pose.position);
+          van.mesh.rotation.y = pose.yaw;
+        }
+        for (const mark of alerts) {
+          mark.scale.y = 1 + Math.sin(now / 420) * 0.08;
+        }
+      }
+      controls.update();
+      renderer.render(scene, camera);
+    };
+    tick();
+
+    return () => {
+      cancelAnimationFrame(frame);
+      ro.disconnect();
+      theme.disconnect();
+      controls.dispose();
+      renderer.dispose();
+      buildingGeo.dispose();
+      vanGeo.dispose();
+      alertGeo.dispose();
+      ground.geometry.dispose();
+      (ground.material as THREE.Material).dispose();
+      buildingMat.dispose();
+      activeMat.dispose();
+      inactiveMat.dispose();
+      alertMat.dispose();
+      if (renderer.domElement.parentNode === el) el.removeChild(renderer.domElement);
+      void parked;
+    };
+  }, []);
+
+  return <div ref={host} className="if-fleet-map" aria-hidden="true" />;
+}

--- a/apps/www/app/interfaces/fleet/page.tsx
+++ b/apps/www/app/interfaces/fleet/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import { interfaceBySlug } from "../catalog";
+import "../interfaces.css";
+import { Board } from "./board";
+
+const proto = interfaceBySlug("fleet")!;
+
+export const metadata: Metadata = {
+  title: proto.title,
+  description: proto.law,
+};
+
+export default function Page() {
+  return <Board />;
+}

--- a/apps/www/app/interfaces/interfaces.css
+++ b/apps/www/app/interfaces/interfaces.css
@@ -1,0 +1,293 @@
+/* Interfaces section. Isolated. Do not move these rules into site.css. */
+
+.if-index {
+  --ml: 0px;
+  display: flex;
+  gap: var(--gutter);
+  padding: 0 var(--pad);
+}
+@media (min-width: 481px) {
+  .if-index {
+    width: calc(max(round(down, 100vw - var(--ml) - 2 * var(--pad) + var(--gutter), 204px), 204px) + var(--gutter));
+  }
+}
+@media (min-width: 1024px) {
+  .if-index {
+    --ml: 204px;
+    margin-left: 204px;
+  }
+}
+@media (min-width: 1700px) {
+  .if-index { max-width: 1244px; }
+}
+
+.if-rail {
+  display: none;
+  flex-shrink: 0;
+  align-self: flex-start;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  width: 184px;
+  padding: 120px 20px 72px 0;
+  overflow-y: auto;
+  scrollbar-width: none;
+  background: var(--bg);
+}
+@media (min-width: 900px) {
+  .if-rail { display: block; }
+}
+.if-rail::-webkit-scrollbar { display: none; }
+.if-rail a {
+  display: block;
+  padding: 5px 0;
+  font-size: 13px;
+  font-weight: 400;
+  letter-spacing: -.01em;
+  color: var(--text-secondary);
+  opacity: .6;
+  text-decoration: none;
+  transition: color .15s ease, opacity .15s ease;
+}
+.if-rail a:hover,
+.if-rail a:focus-visible,
+.if-rail a[aria-current="page"] {
+  color: var(--text);
+  opacity: 1;
+}
+.if-rail a[aria-current="page"] { font-weight: 500; }
+.if-rail a:focus-visible { outline: 1px solid var(--text); outline-offset: 2px; }
+
+.if-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 388px);
+  gap: var(--gutter);
+  padding: 24px 0 72px;
+}
+@media (max-width: 480px) {
+  .if-list { grid-template-columns: 1fr; }
+}
+.if-tile {
+  isolation: isolate;
+  min-height: 204px;
+  background: var(--bg);
+  border: 1px solid var(--divider);
+  border-radius: 0;
+  box-shadow: none;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color .2s ease;
+}
+.if-tile:hover { border-color: var(--text); }
+.if-tile h2 {
+  margin: 0 0 8px;
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -.02em;
+  line-height: 1.2;
+  color: var(--text);
+}
+.if-tile p {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -.01em;
+  line-height: 1.45;
+  color: var(--text-secondary);
+}
+
+/* Boards: working posters. Flush, 204, hairlines, no radius, no shadow. */
+.if-board {
+  --radius: 0;
+  --radius-sm: 0;
+  min-height: 100dvh;
+  background: var(--bg);
+  color: var(--text);
+}
+.if-board,
+.if-board * { border-radius: 0 !important; box-shadow: none !important; }
+.if-app {
+  display: flex;
+  min-height: 100dvh;
+  background: var(--bg);
+}
+.if-app .rs-sidebar {
+  min-height: 100dvh;
+  flex-shrink: 0;
+  padding-top: 64px;
+}
+.if-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 100dvh;
+  border-right: 1px solid var(--divider);
+}
+.if-main:last-child { border-right: none; }
+.if-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 64px;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--divider);
+  background: var(--bg);
+}
+.if-head-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -.01em;
+}
+.if-pane {
+  flex: 1;
+  min-width: 0;
+  padding: 20px;
+  overflow: auto;
+}
+.if-col {
+  width: 408px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 100dvh;
+  background: var(--bg);
+}
+.if-col-narrow { width: 388px; }
+.if-stack { display: flex; flex-direction: column; gap: 16px; }
+.if-row { display: flex; gap: var(--gutter); align-items: flex-start; }
+.if-grid-2 {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--gutter);
+}
+.if-grid-3 {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(184px, 1fr));
+  gap: var(--gutter);
+}
+.if-kicker {
+  margin: 0 0 8px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: -.01em;
+  color: var(--text-secondary);
+}
+.if-copy {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: -.01em;
+  line-height: 1.55;
+  color: var(--text);
+}
+.if-sheet {
+  border: 1px solid var(--divider);
+  border-radius: 0;
+  background: var(--bg);
+  padding: 20px;
+  min-height: 204px;
+}
+.if-board .rs-card { max-width: none; }
+.if-board .rs-ai { max-width: none; }
+.if-board .rs-split { min-height: 408px; }
+.if-board .rs-table { width: 100%; margin: 0; }
+.if-feed { display: flex; flex-direction: column; }
+.if-post {
+  padding: 16px 0;
+  border-bottom: 1px solid var(--divider);
+}
+.if-post:last-child { border-bottom: none; }
+.if-post-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+.if-msg {
+  display: flex;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--divider-subtle);
+}
+.if-msg:last-child { border-bottom: none; }
+.if-msg-body { min-width: 0; flex: 1; }
+.if-msg-who {
+  margin: 0 0 2px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -.01em;
+}
+.if-msg-text {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: -.01em;
+  line-height: 1.5;
+  color: var(--text);
+}
+.if-composer {
+  padding: 12px 20px 20px;
+  border-top: 1px solid var(--divider);
+  background: var(--bg);
+}
+.if-field-spot {
+  padding: 16px;
+  border: 1px solid var(--divider);
+  background: var(--bg);
+}
+
+/* Fleet: map fills the poster; Raster floats on top. */
+.if-fleet {
+  position: relative;
+  min-height: 100dvh;
+  overflow: hidden;
+  background: var(--bg);
+}
+.if-fleet-map {
+  position: absolute;
+  inset: 0;
+}
+.if-fleet-map canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+.if-float {
+  position: absolute;
+  z-index: 2;
+  width: 388px;
+  max-height: calc(100dvh - 88px);
+  overflow: auto;
+  background: var(--bg);
+  border: 1px solid var(--divider);
+  border-radius: 0;
+  box-shadow: none;
+  padding: 16px 20px;
+}
+.if-float-a { top: 72px; left: 20px; }
+.if-float-b { top: 72px; right: 20px; }
+.if-float-c { bottom: 20px; left: 20px; width: 592px; }
+
+@media (max-width: 900px) {
+  .if-col,
+  .if-col-narrow { width: 100%; min-height: 0; }
+  .if-app { flex-direction: column; }
+  .if-app .rs-sidebar { min-height: 0; width: 100%; border-right: none; border-bottom: 1px solid var(--divider); padding-top: 64px; }
+  .if-grid-2 { grid-template-columns: 1fr; }
+  .if-float { position: relative; top: auto; left: auto; right: auto; bottom: auto; width: auto; margin: 12px 20px; }
+  .if-float-c { width: auto; }
+  .if-fleet { overflow: auto; }
+  .if-fleet-map { position: relative; min-height: 408px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .if-tile,
+  .if-rail a { transition: none; }
+}

--- a/apps/www/app/interfaces/nav.tsx
+++ b/apps/www/app/interfaces/nav.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { interfaces } from "./catalog";
+
+function here(pathname: string, href: string) {
+  return pathname === href || pathname === `${href}/`;
+}
+
+export function InterfacesNav() {
+  const pathname = usePathname();
+  return (
+    <nav className="if-rail" aria-label="Interfaces">
+      <Link href="/interfaces" aria-current={here(pathname, "/interfaces") ? "page" : undefined}>
+        Index
+      </Link>
+      {interfaces.map((item) => {
+        const href = `/interfaces/${item.slug}`;
+        return (
+          <Link key={item.slug} href={href} aria-current={here(pathname, href) ? "page" : undefined}>
+            {item.title}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/www/app/interfaces/page.tsx
+++ b/apps/www/app/interfaces/page.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { interfaces } from "./catalog";
+import { InterfacesNav } from "./nav";
+import "./interfaces.css";
+
+export const metadata: Metadata = {
+  title: "Interfaces",
+  description: "Working posters composed from the Raster catalog.",
+};
+
+export default function InterfacesPage() {
+  return (
+    <div className="if-index">
+      <InterfacesNav />
+      <main className="site-content-wide">
+        <header className="cover" style={{ paddingBottom: 24, maxWidth: 592 }}>
+          <h1 className="rs-t-display">Interfaces</h1>
+          <p className="rs-t-sub">Working posters. The catalog, composed.</p>
+        </header>
+        <div className="if-list">
+          {interfaces.map((item) => (
+            <Link key={item.slug} href={`/interfaces/${item.slug}`} className="if-tile">
+              <h2>{item.title}</h2>
+              <p>{item.law}</p>
+            </Link>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/www/app/interfaces/slack/board.tsx
+++ b/apps/www/app/interfaces/slack/board.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import * as React from "react";
+import {
+  Avatar,
+  Badge,
+  Item,
+  ScrollArea,
+  Separator,
+  Sidebar,
+  SidebarFoot,
+  SidebarHead,
+  SidebarItem,
+  SidebarLabel,
+  SidebarNav,
+  Textarea,
+} from "@noordvc/raster-react";
+
+type Kind = "person" | "agent";
+
+type Line = {
+  who: string;
+  initials: string;
+  kind: Kind;
+  body: string;
+};
+
+const CHANNELS = [
+  { id: "press", label: "#press" },
+  { id: "studio", label: "#studio" },
+  { id: "raster", label: "#raster" },
+] as const;
+
+const PEOPLE = [
+  { id: "renn", label: "Renn", kind: "person" as const },
+  { id: "sheet", label: "Sheet", kind: "agent" as const },
+  { id: "proof", label: "Proof", kind: "agent" as const },
+];
+
+const LINES: Record<string, Line[]> = {
+  press: [
+    { who: "Renn", initials: "RV", kind: "person", body: "Press run 14 is on the sheet. Fee is on page one." },
+    { who: "Sheet", initials: "SH", kind: "agent", body: "Logged. Weeks 4–7. I will keep the timeline under the fee." },
+    { who: "Noord", initials: "NO", kind: "person", body: "Proofs stay in the same ink. No hue in the chrome." },
+    { who: "Proof", initials: "PR", kind: "agent", body: "Watching the plate. I will ping if the density drops." },
+    { who: "Renn", initials: "RV", kind: "person", body: "Good. Agents report in the thread, not a second channel." },
+  ],
+  studio: [
+    { who: "Noord", initials: "NO", kind: "person", body: "Alkmaar desk is in. The rail is 204." },
+    { who: "Sheet", initials: "SH", kind: "agent", body: "Calendar is on week 34. Three jobs in proof." },
+    { who: "Renn", initials: "RV", kind: "person", body: "Leave the crumb bar off the poster." },
+  ],
+  raster: [
+    { who: "Renn", initials: "RV", kind: "person", body: "Interfaces is a sibling of Components. Not a buried page." },
+    { who: "Proof", initials: "PR", kind: "agent", body: "Six routes. I will fail CI if one disappears." },
+    { who: "Sheet", initials: "SH", kind: "agent", body: "Catalog only. No second kit." },
+  ],
+  renn: [
+    { who: "Renn", initials: "RV", kind: "person", body: "Hold the spot for the field." },
+    { who: "You", initials: "YO", kind: "person", body: "Chrome stays ink." },
+  ],
+  sheet: [
+    { who: "Sheet", initials: "SH", kind: "agent", body: "I read the brief. Two sentences, same claim." },
+    { who: "You", initials: "YO", kind: "person", body: "Apply it on the canvas, not in chat." },
+    { who: "Sheet", initials: "SH", kind: "agent", body: "Applied. Widget is in the feed." },
+  ],
+  proof: [
+    { who: "Proof", initials: "PR", kind: "agent", body: "Plate 09 is within density." },
+    { who: "You", initials: "YO", kind: "person", body: "Keep watching through the run." },
+  ],
+};
+
+export function Board() {
+  const [room, setRoom] = React.useState("press");
+  const lines = LINES[room] ?? LINES.press!;
+  const title =
+    CHANNELS.find((c) => c.id === room)?.label ?? PEOPLE.find((p) => p.id === room)?.label ?? room;
+  const agentRoom = PEOPLE.find((p) => p.id === room)?.kind === "agent" || lines.some((l) => l.kind === "agent");
+
+  return (
+    <main className="if-board" aria-label="Slack">
+      <div className="if-app">
+        <Sidebar>
+          <SidebarHead>Studio</SidebarHead>
+          <SidebarNav>
+            <SidebarLabel>Channels</SidebarLabel>
+            {CHANNELS.map((item) => (
+              <SidebarItem
+                key={item.id}
+                href={`#${item.id}`}
+                current={room === item.id}
+                onClick={() => setRoom(item.id)}
+              >
+                {item.label}
+              </SidebarItem>
+            ))}
+            <SidebarLabel>People</SidebarLabel>
+            {PEOPLE.map((item) => (
+              <SidebarItem
+                key={item.id}
+                href={`#${item.id}`}
+                current={room === item.id}
+                onClick={() => setRoom(item.id)}
+              >
+                {item.label}
+              </SidebarItem>
+            ))}
+          </SidebarNav>
+          <SidebarFoot>3 people · 2 agents</SidebarFoot>
+        </Sidebar>
+
+        <section className="if-main" aria-label="Chat">
+          <div className="if-head">
+            <p className="if-head-title">{title}</p>
+            <Badge variant={agentRoom ? "muted" : "outline"}>{agentRoom ? "Mixed" : "People"}</Badge>
+          </div>
+          <ScrollArea maxHeight="none" style={{ flex: 1, maxHeight: "none", padding: "8px 20px" }}>
+            {lines.map((line, i) => (
+              <article key={i} className="if-msg">
+                <Avatar initials={line.initials} size="sm" />
+                <div className="if-msg-body">
+                  <p className="if-msg-who">
+                    {line.who}
+                    {line.kind === "agent" ? (
+                      <>
+                        {" "}
+                        <Badge variant="muted">Agent</Badge>
+                      </>
+                    ) : null}
+                  </p>
+                  {line.kind === "agent" ? (
+                    <p className="rs-ai-reply">{line.body}</p>
+                  ) : (
+                    <p className="if-msg-text">{line.body}</p>
+                  )}
+                </div>
+              </article>
+            ))}
+          </ScrollArea>
+          <div className="if-composer">
+            <Textarea label="Message" placeholder={`Write in ${title}`} rows={2} />
+          </div>
+        </section>
+
+        <aside className="if-col-narrow if-col" aria-label="Room">
+          <div className="if-head">
+            <p className="if-head-title">In the room</p>
+          </div>
+          <div className="if-pane">
+            <Item title="Renn" description="Person" meta="Here" />
+            <Item title="Noord" description="Person" meta="Here" />
+            <Item title="Sheet" description="Agent · writes on the canvas" meta="On" />
+            <Item title="Proof" description="Agent · watches the plate" meta="On" />
+            <Separator />
+            <p className="if-kicker">Law</p>
+            <p className="if-copy">Agents sit in the same list as people. The badge is the only tell.</p>
+          </div>
+        </aside>
+      </div>
+    </main>
+  );
+}

--- a/apps/www/app/interfaces/slack/page.tsx
+++ b/apps/www/app/interfaces/slack/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import { interfaceBySlug } from "../catalog";
+import "../interfaces.css";
+import { Board } from "./board";
+
+const proto = interfaceBySlug("slack")!;
+
+export const metadata: Metadata = {
+  title: proto.title,
+  description: proto.law,
+};
+
+export default function Page() {
+  return <Board />;
+}

--- a/apps/www/app/interfaces/threads/board.tsx
+++ b/apps/www/app/interfaces/threads/board.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import * as React from "react";
+import {
+  AspectRatio,
+  Avatar,
+  Badge,
+  Button,
+  Item,
+  ScrollArea,
+  Separator,
+  Sidebar,
+  SidebarFoot,
+  SidebarHead,
+  SidebarItem,
+  SidebarLabel,
+  SidebarNav,
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
+} from "@noordvc/raster-react";
+
+type Post = {
+  id: string;
+  who: string;
+  initials: string;
+  kind: "note" | "image" | "quote";
+  body: string;
+  meta: string;
+  replies: Array<{ who: string; initials: string; body: string }>;
+};
+
+const POSTS: Post[] = [
+  {
+    id: "grid",
+    who: "Renn",
+    initials: "RV",
+    kind: "note",
+    body: "The 204 module is the only join. If a pane needs a second line, it is a second module.",
+    meta: "12 replies",
+    replies: [
+      { who: "Noord", initials: "NO", body: "Keep the hairline on the active tab only." },
+      { who: "Sheet", initials: "SH", body: "The rail stays 184. The gutter is not a stroke." },
+      { who: "Renn", initials: "RV", body: "Agreed. Flush on the left. Internal lines only." },
+    ],
+  },
+  {
+    id: "proof",
+    who: "Noord",
+    initials: "NO",
+    kind: "image",
+    body: "Proof 09 on the press. Same ink, no second color in the chrome.",
+    meta: "4 replies",
+    replies: [
+      { who: "Renn", initials: "RV", body: "Hold the spot for the field, not the frame." },
+      { who: "Press", initials: "PR", body: "Sheet is up at 06:00." },
+    ],
+  },
+  {
+    id: "cite",
+    who: "Sheet",
+    initials: "SH",
+    kind: "quote",
+    body: "A grid is a plan, not a decoration.",
+    meta: "7 replies",
+    replies: [
+      { who: "Renn", initials: "RV", body: "Cite hangs in the gutter. The claim stays in the measure." },
+      { who: "Noord", initials: "NO", body: "Sentence case on the label." },
+    ],
+  },
+];
+
+export function Board() {
+  const [tab, setTab] = React.useState("feed");
+  const [open, setOpen] = React.useState("grid");
+  const post = POSTS.find((p) => p.id === open) ?? POSTS[0]!;
+
+  return (
+    <main className="if-board" aria-label="Threads">
+      <div className="if-app">
+        <Sidebar>
+          <SidebarHead>Thread</SidebarHead>
+          <SidebarNav>
+            <SidebarLabel>Topics</SidebarLabel>
+            <SidebarItem href="#grid" current={open === "grid"} onClick={() => setOpen("grid")}>
+              Grid
+            </SidebarItem>
+            <SidebarItem href="#proof" current={open === "proof"} onClick={() => setOpen("proof")}>
+              Proof
+            </SidebarItem>
+            <SidebarItem href="#cite" current={open === "cite"} onClick={() => setOpen("cite")}>
+              Cite
+            </SidebarItem>
+          </SidebarNav>
+          <SidebarFoot>Following 3</SidebarFoot>
+        </Sidebar>
+
+        <section className="if-main" aria-label="Feed">
+          <div className="if-head">
+            <p className="if-head-title">Feed</p>
+            <Badge variant="muted">Discussion</Badge>
+          </div>
+          <div className="if-pane">
+            <Tabs value={tab} onValueChange={setTab}>
+              <TabList>
+                <Tab value="feed">Feed</Tab>
+                <Tab value="thread">Thread</Tab>
+              </TabList>
+              <TabPanel value="feed">
+                <div className="if-feed" style={{ marginTop: 8 }}>
+                  {POSTS.map((item) => (
+                    <article key={item.id} className="if-post">
+                      <div className="if-post-meta">
+                        <Avatar initials={item.initials} size="sm" />
+                        <span className="if-head-title">{item.who}</span>
+                        <Badge variant={item.kind === "note" ? "outline" : item.kind === "image" ? "solid" : "muted"}>
+                          {item.kind === "note" ? "Note" : item.kind === "image" ? "Image" : "Quote"}
+                        </Badge>
+                      </div>
+                      {item.kind === "quote" ? (
+                        <div className="if-sheet">
+                          <p className="if-kicker">Quoted</p>
+                          <p className="if-copy">{item.body}</p>
+                        </div>
+                      ) : (
+                        <p className="if-copy">{item.body}</p>
+                      )}
+                      {item.kind === "image" ? (
+                        <div style={{ marginTop: 12 }}>
+                          <AspectRatio ratio={16 / 9}>
+                            <div
+                              style={{
+                                width: "100%",
+                                height: "100%",
+                                background: "var(--table-alt)",
+                                border: "1px solid var(--divider)",
+                              }}
+                            />
+                          </AspectRatio>
+                        </div>
+                      ) : null}
+                      <div style={{ marginTop: 12 }}>
+                        <Button variant="ghost" size="sm" onClick={() => { setOpen(item.id); setTab("thread"); }}>
+                          {item.meta}
+                        </Button>
+                      </div>
+                    </article>
+                  ))}
+                </div>
+              </TabPanel>
+              <TabPanel value="thread">
+                <div style={{ marginTop: 16 }}>
+                  <div className="if-post-meta">
+                    <Avatar initials={post.initials} />
+                    <div>
+                      <p className="if-head-title">{post.who}</p>
+                      <p className="if-kicker" style={{ margin: 0 }}>
+                        {post.meta}
+                      </p>
+                    </div>
+                  </div>
+                  <p className="if-copy" style={{ marginTop: 12 }}>
+                    {post.body}
+                  </p>
+                  <Separator />
+                  <ScrollArea maxHeight={320}>
+                    {post.replies.map((reply, i) => (
+                      <Item
+                        key={i}
+                        title={
+                          <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+                            <Avatar initials={reply.initials} size="sm" />
+                            {reply.who}
+                          </span>
+                        }
+                        description={reply.body}
+                      />
+                    ))}
+                  </ScrollArea>
+                </div>
+              </TabPanel>
+            </Tabs>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/www/app/interfaces/threads/page.tsx
+++ b/apps/www/app/interfaces/threads/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import { interfaceBySlug } from "../catalog";
+import "../interfaces.css";
+import { Board } from "./board";
+
+const proto = interfaceBySlug("threads")!;
+
+export const metadata: Metadata = {
+  title: proto.title,
+  description: proto.law,
+};
+
+export default function Page() {
+  return <Board />;
+}

--- a/apps/www/components/crumb-bar.tsx
+++ b/apps/www/components/crumb-bar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import * as React from "react";
 import { rasterComponents } from "@noordvc/raster";
+import { interfaceBySlug } from "@/app/interfaces/catalog";
 import { isFieldPath, isSpecimenPath } from "@/app/specimen";
 
 interface Crumb {
@@ -25,6 +26,12 @@ function trailFor(pathname: string): Crumb[] {
     if (parts[1]) {
       const component = rasterComponents.find((c) => c.name === parts[1]);
       trail.push({ label: component?.title ?? parts[1] });
+    }
+  } else if (parts[0] === "interfaces") {
+    trail.push({ label: "Interfaces", href: "/interfaces" });
+    if (parts[1]) {
+      const proto = interfaceBySlug(parts[1]);
+      trail.push({ label: proto?.title ?? parts[1] });
     }
   }
   return trail;

--- a/apps/www/components/site-chrome.tsx
+++ b/apps/www/components/site-chrome.tsx
@@ -60,6 +60,7 @@ const links = [
   { href: "/", label: "Home", corner: false },
   { href: "/docs", label: "Docs", corner: true },
   { href: "/components", label: "Components", corner: true },
+  { href: "/interfaces", label: "Interfaces", corner: true },
   { href: "/about", label: "About", corner: true },
 ];
 

--- a/apps/www/next.config.mjs
+++ b/apps/www/next.config.mjs
@@ -2,7 +2,7 @@
 const nextConfig = {
   output: "export",
   trailingSlash: true,
-  transpilePackages: ["@noordvc/raster", "@noordvc/raster-react"],
+  transpilePackages: ["@noordvc/raster", "@noordvc/raster-react", "three"],
 };
 
 export default nextConfig;

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -17,12 +17,14 @@
     "@noordvc/raster-react": "workspace:*",
     "next": "^15.1.6",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "three": "^0.184.0"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
+    "@types/three": "^0.184.0",
     "typescript": "^5.7.3"
   }
 }

--- a/apps/www/scripts/check-interfaces.mjs
+++ b/apps/www/scripts/check-interfaces.mjs
@@ -1,0 +1,98 @@
+// The Interfaces section is six first-class posters. Fail if a route
+// disappears, if the section is buried in Components, or if a second kit
+// (Tailwind / Radix) appears in the section.
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("../../..", import.meta.url));
+const dir = join(root, "apps/www/app/interfaces");
+const slugs = ["ai-tool", "dashboard", "threads", "fleet", "delivery", "slack"];
+
+if (!existsSync(join(dir, "FEATURE.md"))) {
+  console.error("Interfaces feature map missing: app/interfaces/FEATURE.md");
+  process.exit(1);
+}
+if (!existsSync(join(dir, "catalog.ts"))) {
+  console.error("Interfaces catalog missing: app/interfaces/catalog.ts");
+  process.exit(1);
+}
+if (!existsSync(join(dir, "page.tsx"))) {
+  console.error("Interfaces index missing: app/interfaces/page.tsx");
+  process.exit(1);
+}
+
+const catalog = readFileSync(join(dir, "catalog.ts"), "utf8");
+const index = readFileSync(join(dir, "page.tsx"), "utf8");
+const map = readFileSync(join(dir, "FEATURE.md"), "utf8");
+const chrome = readFileSync(join(root, "apps/www/components/site-chrome.tsx"), "utf8");
+const crumbs = readFileSync(join(root, "apps/www/components/crumb-bar.tsx"), "utf8");
+
+if (!chrome.includes('href: "/interfaces"') || !chrome.includes('label: "Interfaces"')) {
+  console.error("Interfaces must be a first-class corner-nav sibling");
+  process.exit(1);
+}
+if (!crumbs.includes('label: "Interfaces"') || !crumbs.includes("interfaceBySlug")) {
+  console.error("Crumb bar must trail Interfaces");
+  process.exit(1);
+}
+
+const folders = readdirSync(dir).filter((name) => statSync(join(dir, name)).isDirectory());
+const missing = slugs.filter((slug) => !folders.includes(slug) || !existsSync(join(dir, slug, "page.tsx")));
+if (missing.length) {
+  console.error("Missing Interfaces routes:\n" + missing.map((s) => `  /interfaces/${s}`).join("\n"));
+  process.exit(1);
+}
+const extras = folders.filter((name) => !slugs.includes(name));
+if (extras.length) {
+  console.error("Unexpected Interfaces folders:\n" + extras.map((s) => `  ${s}`).join("\n"));
+  process.exit(1);
+}
+
+if (!index.includes("interfaces.map") || !index.includes("`/interfaces/${item.slug}`")) {
+  console.error("Interfaces index must list the six from catalog.ts");
+  process.exit(1);
+}
+
+for (const slug of slugs) {
+  if (!catalog.includes(`slug: "${slug}"`)) {
+    console.error(`catalog.ts is missing slug: ${slug}`);
+    process.exit(1);
+  }
+  if (!map.includes(`/interfaces/${slug}`)) {
+    console.error(`FEATURE.md does not name /interfaces/${slug}`);
+    process.exit(1);
+  }
+}
+
+const walk = (from) => {
+  const out = [];
+  for (const name of readdirSync(from)) {
+    const path = join(from, name);
+    if (statSync(path).isDirectory()) out.push(...walk(path));
+    else out.push(path);
+  }
+  return out;
+};
+
+const banned = /tailwind|@radix-ui|@radix\//;
+for (const file of walk(dir)) {
+  const text = readFileSync(file, "utf8");
+  if (banned.test(text)) {
+    console.error(`Interfaces must stay off Tailwind and Radix: ${file}`);
+    process.exit(1);
+  }
+}
+
+const componentsPage = readFileSync(join(root, "apps/www/app/components/page.tsx"), "utf8");
+if (componentsPage.includes("/interfaces")) {
+  console.error("Interfaces must not be buried inside the Components page");
+  process.exit(1);
+}
+
+if (!existsSync(join(dir, "fleet", "map.tsx"))) {
+  console.error("Fleet proto must keep its three.js map in fleet/map.tsx");
+  process.exit(1);
+}
+
+console.log(`ok: ${slugs.length} Interfaces routes`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.8(react@19.2.8)
+      three:
+        specifier: ^0.184.0
+        version: 0.184.0
     devDependencies:
       '@types/node':
         specifier: ^26.1.1
@@ -35,6 +38,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.3
         version: 19.2.3(@types/react@19.2.17)
+      '@types/three':
+        specifier: ^0.184.0
+        version: 0.184.1
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -156,6 +162,9 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@emnapi/runtime@1.11.2':
     resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
@@ -826,6 +835,9 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -848,6 +860,15 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/three@0.184.1':
+    resolution: {integrity: sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@vitest/expect@3.2.7':
     resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
@@ -1015,6 +1036,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
@@ -1084,6 +1108,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  meshoptimizer@1.1.1:
+    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
@@ -1279,6 +1306,9 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  three@0.184.0:
+    resolution: {integrity: sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1514,6 +1544,8 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@emnapi/runtime@1.11.2':
     dependencies:
@@ -1917,6 +1949,8 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
@@ -1939,6 +1973,19 @@ snapshots:
   '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
+
+  '@types/stats.js@0.17.4': {}
+
+  '@types/three@0.184.1':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      fflate: 0.8.3
+      meshoptimizer: 1.1.1
+
+  '@types/webxr@0.5.24': {}
 
   '@vitest/expect@3.2.7':
     dependencies:
@@ -2128,6 +2175,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
+  fflate@0.8.3: {}
+
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
       magic-string: 0.30.21
@@ -2209,6 +2258,8 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  meshoptimizer@1.1.1: {}
 
   mlly@1.8.2:
     dependencies:
@@ -2427,6 +2478,8 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  three@0.184.0: {}
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebased onto current `origin/main` after #4 (`fe2f36e`). Keeps both the six Interfaces posters and the homepage/About recut. No new features.

Six first-class interface posters, composed from the Raster catalog. New branch from `main` — not stacked on the catalog-rail PR. Do not merge. Do not npm publish.

## Section

**Interfaces** is a corner-nav sibling of Docs, Components, and About. It is not a page inside a component.

- Index: `/interfaces` — lists the six
- Each proto is its own folder and route

| Proto | Route |
| --- | --- |
| AI tool | `/interfaces/ai-tool` |
| SaaS dashboard | `/interfaces/dashboard` |
| Threads | `/interfaces/threads` |
| Fleet | `/interfaces/fleet` |
| Food delivery | `/interfaces/delivery` |
| Slack | `/interfaces/slack` |

Feature map: `apps/www/app/interfaces/FEATURE.md`.

## Locks

Inter, 204 module, hairlines, flush, no radius, no shadow, no Tailwind, no Radix. Chrome monochrome. Boards may use one Crouwel spot. Sentence case. Raster components only.

Fleet floats Raster cards on a three.js map. The scene borrows the noord.vc homepage technique (perspective field, fog, instanced mass, CSS-token paint, quiet auto-rotate). It does not clone the marketing site.

## CI

`apps/www/scripts/check-interfaces.mjs` plus the **Interfaces is six posters** job fail if any of the six routes disappear, if the section is buried in Components, or if Tailwind/Radix shows up in the section.

## Testing

Local package tests and the Interfaces check are green. Preview screenshots of the index, AI tool, dashboard, fleet (map visible), and Slack will follow on this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2eb65fb1-4d79-410c-a88d-9126e9ce09e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2eb65fb1-4d79-410c-a88d-9126e9ce09e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

