### PR TITLE
Recut Raster homepage and About

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           grep -q 'POSTER' apps/www/app/page.tsx
           test -f apps/www/app/specimen-kit.tsx
           test -f apps/www/app/specimen-laws.ts
-          if grep -nE 'height: 100dvh' apps/www/app/specimen.css; then
+          if grep -nE '^[[:space:]]*height: 100dvh' apps/www/app/specimen.css; then
             echo "Specimen must scroll; do not lock height to the viewport"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
           grep -q 'WORD = "Raster"' "$writer"
           grep -q '{WORD}' "$page"
           grep -q 'A poster you can install.' "$writer"
+          grep -q 'A design system on a modular grid.' "$writer"
           grep -q 'npx @noordvc/raster-cli init' "$writer"
           if grep -n -E 'One ink|204 module|Crouwel|Müller-Brockmann' "$page" "$writer" apps/www/app/layout.tsx apps/www/app/social.ts; then
             echo "Homepage law must not use the old museum caption"
@@ -101,19 +102,39 @@ jobs:
           fi
           grep -q 'padding: 0 1px 1px 0' apps/www/app/specimen.css
           grep -q 'KIT =' apps/www/app/specimen.ts
-          grep -q 'button-group' apps/www/app/specimen.ts
-          grep -q 'tabs' apps/www/app/specimen.ts
-          grep -q 'chart' apps/www/app/specimen.ts
+          grep -q 'accordion' apps/www/app/specimen.ts
+          grep -q 'calendar' apps/www/app/specimen.ts
+          grep -q 'field' apps/www/app/specimen.ts
+          grep -q 'stepper' apps/www/app/specimen.ts
           grep -q 'SpecimenKit' apps/www/app/page.tsx
+          grep -q 'SpecimenPrinciples' apps/www/app/page.tsx
+          grep -q 'POSTER' apps/www/app/page.tsx
           test -f apps/www/app/specimen-kit.tsx
+          test -f apps/www/app/specimen-laws.ts
+          if grep -nE 'height: 100dvh' apps/www/app/specimen.css; then
+            echo "Specimen must scroll; do not lock height to the viewport"
+            exit 1
+          fi
+          if grep -n 'overflow: hidden' apps/www/app/specimen.css; then
+            echo "Kit cells must not crop"
+            exit 1
+          fi
           if grep -nE 'Save|Draft|rs-switch' apps/www/app/page.tsx apps/www/app/specimen-kit.tsx; then
             echo "Homepage kit cells must not be the leftover Save / switch / Draft set"
+            exit 1
+          fi
+          if grep -nE '"button-group"|"tabs"|"chart"' apps/www/app/specimen.ts; then
+            echo "Homepage kit must not reuse the cropped button-group / tabs / chart cells"
             exit 1
           fi
           node -e '
             const { readFileSync } = require("node:fs");
             const spec = readFileSync("apps/www/app/specimen.ts", "utf8");
-            const names = [...spec.matchAll(/"(button-group|tabs|chart)"/g)].map((m) => m[1]);
+            const names = [...spec.matchAll(/"(accordion|calendar|field|stepper)"/g)].map((m) => m[1]);
+            if (names.length !== 4) {
+              console.error("KIT must name accordion, calendar, field, stepper");
+              process.exit(1);
+            }
             const reg = readFileSync("packages/core/src/registry.ts", "utf8");
             for (const name of names) {
               if (!reg.includes(`name: "${name}"`)) {
@@ -184,9 +205,23 @@ jobs:
           grep -q 'meta.url' "$facts"
           grep -q '@noordvc/raster' "$facts"
           grep -q 'type.foundry' "$facts"
+          grep -q 'AI lab' "$facts"
+          grep -q 'Alkmaar' "$facts"
+          grep -q 'Silicon Valley' "$facts"
+          grep -q 'designed and built' "$facts"
           grep -q 'masthead-typeface' "$page"
           grep -q 'masthead-noord' "$page"
           grep -q 'masthead-renato' "$page"
+          grep -q 'field-page' "$page"
+          grep -q 'field-face' "$css"
+          if grep -nE 'venture studio|Ten portfolio|ten portfolio' "$facts" "$page"; then
+            echo "About must not lead with the venture-studio line"
+            exit 1
+          fi
+          if grep -n 'overflow: hidden' "$css"; then
+            echo "About field cells must not crop"
+            exit 1
+          fi
           grep -q 'SIL OFL 1.1' packages/core/src/tokens.ts
           if grep -n Messina "$page" "$facts" "$css"; then
             echo "About must not name Messina"

--- a/apps/www/app/about/about.css
+++ b/apps/www/app/about/about.css
@@ -1,112 +1,201 @@
-/* About / masthead. Isolated. Do not move these rules into site.css. */
+/* About / field. Isolated. Do not move these rules into site.css. */
 
-.masthead-page {
-  padding: 0 20px 72px;
-  max-width: 836px;
+.field-page {
+  width: 100%;
+  min-height: 100dvh;
 }
 
-.masthead {
+.field {
+  display: grid;
+  width: 100%;
+  min-height: 100dvh;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-areas:
+    "word"
+    "lead"
+    "inter"
+    "type"
+    "pkg"
+    "door"
+    "host"
+    "who"
+    "mit";
+  grid-auto-rows: minmax(204px, auto);
+  background: var(--divider);
+  padding: 0 1px 1px 0;
+  gap: 1px;
+}
+
+.field-cell {
+  min-width: 0;
   min-height: 204px;
-  padding: 120px 0 40px;
-  border-bottom: 1px solid var(--divider);
+  padding: 20px;
+  background: var(--bg);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 16px;
+  overflow: visible;
 }
 
-.masthead-word {
+.field-cell-word {
+  grid-area: word;
+  container-type: inline-size;
+  justify-content: flex-end;
+  min-height: 408px;
+}
+
+.field-cell-lead {
+  grid-area: lead;
+  justify-content: space-between;
+}
+
+.field-cell-inter {
+  grid-area: inter;
+  container-type: inline-size;
+  justify-content: flex-end;
+  min-height: 408px;
+}
+
+.field-cell-type { grid-area: type; }
+.field-cell-pkg { grid-area: pkg; }
+.field-cell-door { grid-area: door; }
+.field-cell-host { grid-area: host; }
+.field-cell-who { grid-area: who; justify-content: flex-end; }
+.field-cell-mit { grid-area: mit; }
+
+.field-face {
   margin: 0;
-  font-size: clamp(52px, 10vw, 88px);
+  font-size: clamp(4.5rem, 28cqw, 18rem);
+  font-weight: 600;
+  letter-spacing: -.045em;
+  line-height: .82;
+  color: var(--text);
+}
+
+.field-face-sub {
+  font-size: clamp(3.5rem, 22cqw, 12rem);
+}
+
+.field-name {
+  margin: 0;
+  font-size: clamp(28px, 5vw, 52px);
   font-weight: 600;
   letter-spacing: -.035em;
   line-height: .95;
-  color: var(--text);
-}
-
-.masthead-law {
-  margin: 16px 0 0;
-  max-width: 28em;
-  font-size: 17px;
-  font-weight: 500;
-  letter-spacing: -.01em;
-  line-height: 1.45;
-  color: var(--text);
-}
-
-.masthead-block {
-  display: grid;
-  grid-template-columns: 184px minmax(0, 1fr);
-  min-height: 204px;
-  border-bottom: 1px solid var(--divider);
-  background: var(--bg);
-}
-
-.masthead-block h2 {
-  margin: 0;
-  padding: 20px 16px 18px;
-  border-right: 1px solid var(--divider);
-  font-size: clamp(22px, 3.6vw, 32px);
-  font-weight: 600;
-  letter-spacing: -.03em;
-  line-height: .95;
-  color: var(--text);
-  display: flex;
-  align-items: flex-end;
   text-wrap: balance;
+  max-width: 8em;
 }
 
-.masthead-copy {
-  padding: 20px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 12px;
-  min-width: 0;
-}
-
-.masthead-copy p,
-.masthead-copy ul {
+.field-kicker {
   margin: 0;
-  font-size: 14px;
-  font-weight: 500;
-  letter-spacing: -.01em;
-  line-height: 1.5;
-  color: var(--text);
-  max-width: 36em;
-}
-
-.masthead-copy ul {
-  padding: 0;
-  list-style: none;
-}
-
-.masthead-copy li + li { margin-top: 8px; }
-
-.masthead-kicker {
   font-size: 12px;
   font-weight: 600;
   letter-spacing: -.01em;
   color: var(--text-secondary);
 }
 
-.masthead-copy a {
+.field-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 28em;
+}
+
+.field-copy p {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 500;
+  letter-spacing: -.01em;
+  line-height: 1.5;
+  color: var(--text);
+}
+
+.field-names {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field-names li {
+  font-size: clamp(18px, 3vw, 28px);
+  font-weight: 600;
+  letter-spacing: -.03em;
+  line-height: 1.15;
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+
+.field-url {
+  margin: 0;
+  font-size: clamp(22px, 4vw, 36px);
+  font-weight: 600;
+  letter-spacing: -.03em;
+  line-height: 1.1;
+  overflow-wrap: anywhere;
+}
+
+.field-cell a {
   color: var(--text);
   text-decoration: none;
   border-bottom: 1px solid var(--divider);
 }
 
-.masthead-copy a:hover { border-color: var(--text); }
+.field-cell a:hover { border-color: var(--text); }
 
-.masthead-copy a:link,
-.masthead-copy a:visited,
-.masthead-copy a:any-link {
+.field-cell a:link,
+.field-cell a:visited,
+.field-cell a:any-link {
   color: var(--text);
 }
 
-@media (max-width: 640px) {
-  .masthead { padding-top: 72px; }
-  .masthead-block { grid-template-columns: 1fr; min-height: 0; }
-  .masthead-block h2 {
-    border-right: none;
-    border-bottom: 1px solid var(--divider);
-    min-height: 88px;
-    font-size: 28px;
+.field-url a {
+  border-bottom: none;
+}
+
+.field-url a:hover {
+  border-bottom: 1px solid var(--text);
+}
+
+@media (min-width: 408px) {
+  .field {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-areas:
+      "word word"
+      "lead lead"
+      "inter inter"
+      "type type"
+      "pkg pkg"
+      "door host"
+      "who who"
+      "mit mit";
+  }
+}
+
+@media (min-width: 816px) {
+  .field {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-areas:
+      "word word word word"
+      "word word word word"
+      "lead lead lead lead"
+      "inter inter type type"
+      "pkg pkg door host"
+      "who who mit mit";
+  }
+}
+
+@media (min-width: 1224px) {
+  .field {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    grid-template-areas:
+      "word word word lead lead lead"
+      "word word word lead lead lead"
+      "inter inter inter type type type"
+      "pkg pkg pkg door door host"
+      "who who who who mit mit";
   }
 }

--- a/apps/www/app/about/facts.ts
+++ b/apps/www/app/about/facts.ts
@@ -1,17 +1,13 @@
 /**
- * Masthead facts. Every string is already in this repo.
- * Do not invent a bio, a license, or a credit.
+ * About facts. Every string is already known, or written from known facts.
+ * Do not invent a bio, a client list, a headcount, or a product.
  *
  * Sources:
  *   packages/core/src/tokens.ts          type.foundry, meta.url
  *   packages/core/css/fonts/inter/OFL.txt
- *   README.md                            typeface, packages, principles
+ *   README.md                            typeface, packages
  *   LICENSE                              copyright line
- *   apps/www/app/specimen.ts             word, law
- *   packages/core/src/registry.ts        hover-card snippet (Noord)
- *   apps/www/package.json                docs-site runtime packages
- *   apps/www/node_modules/{next,react,react-dom}/package.json
- *   vercel.json                          deploy
+ *   apps/www/app/specimen.ts             word, door, host
  *   package.json                         homepage, repository
  */
 
@@ -35,7 +31,10 @@ export const typeface = {
 
 export const noord = {
   heading: "Noord",
-  what: "Noord, a venture studio in Alkmaar. Ten portfolio companies, one design system.",
+  span: "Alkmaar ↔ Silicon Valley",
+  what: "Noord is an AI lab between Alkmaar and Silicon Valley.",
+  built: "Raster was designed and built there.",
+  who: "Renato Valdés Olmos led design and development for Raster at Noord.",
   door: DOOR,
   host: rasterTokens.meta.url,
   packages: ["@noordvc/raster", "@noordvc/raster-react", "@noordvc/raster-cli"] as const,
@@ -48,36 +47,3 @@ export const person = {
   year: "2026",
   repo: "https://github.com/rennvaldes/raster",
 };
-
-/** Runtime and vendored third parties, licenses read from this repo. */
-export const credits: Array<{ name: string; license: string; note: string; href?: string }> = [
-  {
-    name: "Inter",
-    license: "SIL OFL 1.1",
-    note: "Vendored at packages/core/css/fonts/inter.",
-    href: foundry.url,
-  },
-  {
-    name: "Next.js",
-    license: "MIT",
-    note: "Docs site. apps/www depends on next.",
-    href: "https://nextjs.org",
-  },
-  {
-    name: "React",
-    license: "MIT",
-    note: "Docs site, and a peer of @noordvc/raster-react.",
-    href: "https://react.dev",
-  },
-  {
-    name: "React DOM",
-    license: "MIT",
-    note: "Docs site, and a peer of @noordvc/raster-react.",
-  },
-  {
-    name: "Vercel",
-    license: "—",
-    note: "This repo’s vercel.json builds apps/www. Not a runtime package.",
-    href: "https://vercel.com",
-  },
-];

--- a/apps/www/app/about/page.tsx
+++ b/apps/www/app/about/page.tsx
@@ -1,76 +1,95 @@
 import type { Metadata } from "next";
-import { credits, law, noord, person, typeface, word } from "./facts";
+import { noord, person, typeface } from "./facts";
 import "./about.css";
 
 export const metadata: Metadata = {
   title: "About",
-  description: law,
+  description: noord.what,
 };
 
 export default function AboutPage() {
   return (
-    <main className="masthead-page" aria-label="About Raster">
-      <header className="masthead">
-        <p className="masthead-word">{word}</p>
-        <p className="masthead-law">{law}</p>
-      </header>
+    <main className="field-page" aria-label="About Raster">
+      <div className="field">
+        <section className="field-cell field-cell-word" aria-labelledby="masthead-noord">
+          <h1 id="masthead-noord" className="field-face">
+            {noord.heading}
+          </h1>
+        </section>
 
-      <section className="masthead-block" aria-labelledby="masthead-typeface">
-        <h2 id="masthead-typeface">{typeface.heading}</h2>
-        <div className="masthead-copy">
-          <p className="masthead-kicker">
-            {typeface.name} · {typeface.license}
-          </p>
-          <p>
-            Designed by {typeface.designer}. {typeface.ofl}.{" "}
-            <a href={typeface.url}>{typeface.url.replace("https://", "")}</a>
-          </p>
-          <p>{typeface.why}</p>
-        </div>
-      </section>
+        <section className="field-cell field-cell-lead">
+          <p className="field-kicker">{noord.span}</p>
+          <div className="field-copy">
+            <p>{noord.what}</p>
+            <p>{noord.built}</p>
+            <p>{noord.who}</p>
+          </div>
+        </section>
 
-      <section className="masthead-block" aria-labelledby="masthead-noord">
-        <h2 id="masthead-noord">{noord.heading}</h2>
-        <div className="masthead-copy">
-          <p>{noord.what}</p>
-          <p>
-            <a href={noord.door}>{noord.door.replace("https://", "")}</a>
-            {" is the door. Host today: "}
-            <a href={noord.host}>{noord.host.replace("https://", "")}</a>
-            . Packages: {noord.packages.join(", ")}.
-          </p>
-          <p>
-            <code className="rs-code">{noord.command}</code>
-          </p>
-        </div>
-      </section>
+        <section className="field-cell field-cell-inter" aria-labelledby="masthead-typeface">
+          <h2 id="masthead-typeface" className="field-face field-face-sub">
+            {typeface.name}
+          </h2>
+        </section>
 
-      <section className="masthead-block" aria-labelledby="masthead-renato">
-        <h2 id="masthead-renato">{person.heading}</h2>
-        <div className="masthead-copy">
-          <p>
-            {person.copyright}, {person.year}. The repository is{" "}
-            <a href={person.repo}>github.com/rennvaldes/raster</a>.
+        <section className="field-cell field-cell-type">
+          <p className="field-kicker">
+            {typeface.heading} · {typeface.license}
           </p>
-        </div>
-      </section>
+          <div className="field-copy">
+            <p>
+              Designed by {typeface.designer}. {typeface.ofl}.{" "}
+              <a href={typeface.url}>{typeface.url.replace("https://", "")}</a>
+            </p>
+            <p>{typeface.why}</p>
+          </div>
+        </section>
 
-      <section className="masthead-block" aria-labelledby="masthead-credits">
-        <h2 id="masthead-credits">Credits</h2>
-        <div className="masthead-copy">
-          <p className="masthead-kicker">From the package list in this repo</p>
-          <ul>
-            {credits.map((item) => (
-              <li key={item.name}>
-                {item.href ? <a href={item.href}>{item.name}</a> : item.name}
-                {item.license !== "—" ? ` · ${item.license}` : null}
-                {". "}
-                {item.note}
-              </li>
+        <section className="field-cell field-cell-pkg">
+          <p className="field-kicker">Packages</p>
+          <ul className="field-names">
+            {noord.packages.map((name) => (
+              <li key={name}>{name}</li>
             ))}
           </ul>
-        </div>
-      </section>
+        </section>
+
+        <section className="field-cell field-cell-door">
+          <p className="field-kicker">Door</p>
+          <p className="field-url">
+            <a href={noord.door}>{noord.door.replace("https://", "")}</a>
+          </p>
+        </section>
+
+        <section className="field-cell field-cell-host">
+          <p className="field-kicker">Host</p>
+          <p className="field-url">
+            <a href={noord.host}>{noord.host.replace("https://", "")}</a>
+          </p>
+        </section>
+
+        <section className="field-cell field-cell-who" aria-labelledby="masthead-renato">
+          <h2 id="masthead-renato" className="field-name">
+            {person.heading}
+          </h2>
+        </section>
+
+        <section className="field-cell field-cell-mit">
+          <p className="field-kicker">MIT</p>
+          <div className="field-copy">
+            <p>
+              {person.copyright}, {person.year}.
+            </p>
+            <p>
+              The repository is{" "}
+              <a href={person.repo}>github.com/rennvaldes/raster</a>.
+            </p>
+            <p>
+              <code className="rs-code">{noord.command}</code>
+            </p>
+          </div>
+        </section>
+      </div>
     </main>
   );
 }

--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 import type { Metadata } from "next";
-import { COMMAND, LAW, WORD } from "./specimen";
+import { COMMAND, LAW, POSTER, WORD } from "./specimen";
 import { SpecimenKit } from "./specimen-kit";
+import { SpecimenPrinciples } from "./specimen-principles";
 import "./specimen.css";
 
 export const metadata: Metadata = {
@@ -21,6 +22,12 @@ export default function Home() {
           <h1 className="specimen-law">{LAW}</h1>
         </section>
 
+        <SpecimenPrinciples />
+
+        <section className="specimen-cell specimen-cell-note">
+          <p className="specimen-poster">{POSTER}</p>
+        </section>
+
         <section className="specimen-cell specimen-cell-command">
           <p className="specimen-command">{COMMAND}</p>
           <p className="specimen-command-meta">
@@ -31,8 +38,6 @@ export default function Home() {
         </section>
 
         <SpecimenKit />
-
-        <div className="specimen-cell specimen-cell-empty" aria-hidden="true" />
       </div>
     </main>
   );

--- a/apps/www/app/specimen-kit.tsx
+++ b/apps/www/app/specimen-kit.tsx
@@ -5,17 +5,19 @@ import { rasterComponents } from "@noordvc/raster";
 import { Preview } from "@/components/preview";
 import { KIT } from "./specimen";
 
+const slots = ["a", "b", "c", "d"] as const;
+
 export function SpecimenKit() {
   return (
     <>
       {KIT.map((name, i) => {
         const component = rasterComponents.find((c) => c.name === name);
         if (!component) return null;
-        const slot = ["a", "b", "c"][i] ?? "a";
+        const slot = slots[i] ?? "a";
         return (
           <section
             key={component.name}
-            className={`specimen-cell specimen-cell-demo specimen-cell-kit-${slot}`}
+            className={`specimen-cell specimen-cell-demo specimen-cell-kit-${slot} specimen-cell-kit-${component.name}`}
             aria-label={component.title}
           >
             <p className="specimen-kit-name">

--- a/apps/www/app/specimen-laws.ts
+++ b/apps/www/app/specimen-laws.ts
@@ -1,0 +1,17 @@
+/**
+ * Numbered laws for the homepage field.
+ * Short. Modular. The grid is the idea.
+ */
+
+export const PRINCIPLES = [
+  { n: "01", text: "The grid is the idea." },
+  { n: "02", text: "One face." },
+  { n: "03", text: "Hairlines, not boxes." },
+  { n: "04", text: "One ink." },
+  { n: "05", text: "Sentence case." },
+  { n: "06", text: "The module is enough." },
+  { n: "07", text: "Flush." },
+  { n: "08", text: "Weight and size do the work." },
+  { n: "09", text: "Motion is quiet." },
+  { n: "10", text: "As little as the field allows." },
+] as const;

--- a/apps/www/app/specimen-principles.tsx
+++ b/apps/www/app/specimen-principles.tsx
@@ -1,0 +1,20 @@
+import { PRINCIPLES } from "./specimen-laws";
+
+export function SpecimenPrinciples() {
+  return (
+    <>
+      {PRINCIPLES.map((law) => (
+        <section
+          key={law.n}
+          className={`specimen-cell specimen-cell-principle specimen-cell-p${law.n}`}
+          aria-label={`Law ${law.n}`}
+        >
+          <p className="specimen-n" aria-hidden="true">
+            {law.n}
+          </p>
+          <p className="specimen-n-text">{law.text}</p>
+        </section>
+      ))}
+    </>
+  );
+}

--- a/apps/www/app/specimen.css
+++ b/apps/www/app/specimen.css
@@ -12,10 +12,22 @@
   grid-template-areas:
     "face"
     "law"
-    "command"
+    "p01"
+    "p02"
+    "p03"
+    "p04"
+    "p05"
+    "p06"
+    "p07"
+    "p08"
+    "p09"
+    "p10"
+    "note"
     "kita"
     "kitb"
-    "kitc";
+    "kitc"
+    "kitd"
+    "cmd";
   grid-auto-rows: minmax(204px, auto);
   /* Internal 1px gaps are the module lines. Top and left stay flush. */
   background: var(--divider);
@@ -42,8 +54,22 @@
   container-type: inline-size;
   justify-content: flex-end;
 }
+.specimen-cell-p01 { grid-area: p01; }
+.specimen-cell-p02 { grid-area: p02; }
+.specimen-cell-p03 { grid-area: p03; }
+.specimen-cell-p04 { grid-area: p04; }
+.specimen-cell-p05 { grid-area: p05; }
+.specimen-cell-p06 { grid-area: p06; }
+.specimen-cell-p07 { grid-area: p07; }
+.specimen-cell-p08 { grid-area: p08; }
+.specimen-cell-p09 { grid-area: p09; }
+.specimen-cell-p10 { grid-area: p10; }
+.specimen-cell-note {
+  grid-area: note;
+  justify-content: flex-end;
+}
 .specimen-cell-command {
-  grid-area: command;
+  grid-area: cmd;
   container-type: inline-size;
   justify-content: space-between;
   gap: 16px;
@@ -51,11 +77,7 @@
 .specimen-cell-kit-a { grid-area: kita; }
 .specimen-cell-kit-b { grid-area: kitb; }
 .specimen-cell-kit-c { grid-area: kitc; }
-.specimen-cell-empty {
-  display: none;
-  grid-area: rest;
-  padding: 0;
-}
+.specimen-cell-kit-d { grid-area: kitd; }
 .specimen-face {
   margin: 0;
   font-size: clamp(4.5rem, 30cqw, 24rem);
@@ -66,12 +88,44 @@
 }
 .specimen-law {
   margin: 0;
-  font-size: clamp(1.5rem, 14cqw, 4.5rem);
+  font-size: clamp(1.5rem, 12cqw, 3.75rem);
   font-weight: 600;
   letter-spacing: -.035em;
   line-height: 1;
   text-wrap: balance;
-  max-width: 8.5em;
+  max-width: 9em;
+}
+.specimen-cell-principle {
+  justify-content: space-between;
+  gap: 16px;
+}
+.specimen-n {
+  margin: 0;
+  font-size: clamp(52px, 10vw, 88px);
+  font-weight: 600;
+  letter-spacing: -.045em;
+  line-height: .85;
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+}
+.specimen-cell-p01 .specimen-n {
+  font-size: clamp(72px, 14vw, 120px);
+}
+.specimen-n-text {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 500;
+  letter-spacing: -.015em;
+  line-height: 1.3;
+  text-wrap: balance;
+  max-width: 12em;
+}
+.specimen-poster {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -.01em;
+  color: var(--text-secondary);
 }
 .specimen-command {
   margin: 0;
@@ -99,8 +153,10 @@
 .specimen-cell-demo {
   justify-content: space-between;
   align-items: stretch;
-  gap: 12px;
-  overflow: hidden;
+  gap: 16px;
+}
+.specimen-cell-kit-calendar {
+  min-height: 408px;
 }
 .specimen-kit-name {
   margin: 0;
@@ -115,65 +171,69 @@
 }
 .specimen-kit-name a:hover { border-color: var(--text); }
 .specimen-kit-live {
-  flex: 1;
   min-width: 0;
-  min-height: 0;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  align-items: flex-start;
+  justify-content: flex-start;
 }
-.specimen-kit-live > div {
-  width: 100% !important;
-  max-width: 100%;
-}
-.specimen-kit-live .rs-chart,
-.specimen-kit-live .rs-chart-field,
 .specimen-kit-live .rs-btn-group,
-.specimen-kit-live .rs-tabs {
-  width: 100%;
-  max-width: 100%;
+.specimen-kit-live .rs-tabs,
+.specimen-kit-live .rs-acc,
+.specimen-kit-live .rs-field,
+.specimen-kit-live .rs-steps,
+.specimen-kit-live .rs-cal {
   border-radius: 0;
   box-shadow: none;
 }
-.specimen-kit-live .rs-chart-field { padding: 10px; }
 
 @media (min-width: 408px) {
   .specimen {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     grid-template-areas:
       "face face"
-      "face face"
       "law law"
-      "command command"
-      "kita kitb"
-      "kitc rest";
-    grid-auto-rows: minmax(204px, 1fr);
+      "p01 p02"
+      "p03 p04"
+      "p05 p06"
+      "p07 p08"
+      "p09 p10"
+      "note cmd"
+      "kita kita"
+      "kitb kitb"
+      "kitc kitc"
+      "kitd kitd";
   }
-  .specimen-cell-empty { display: block; }
 }
 
 @media (min-width: 816px) {
   .specimen {
     grid-template-columns: repeat(4, minmax(0, 1fr));
     grid-template-areas:
-      "face face face law"
-      "face face face law"
-      "command command command command"
-      "kita kitb kitc rest";
+      "face face face face"
+      "face face face face"
+      "law law law law"
+      "p01 p01 p02 p02"
+      "p03 p03 p04 p04"
+      "p05 p05 p06 p06"
+      "p07 p07 p08 p08"
+      "p09 p09 p10 p10"
+      "note note cmd cmd"
+      "kita kita kitb kitb"
+      "kitc kitc kitd kitd";
   }
 }
 
 @media (min-width: 1224px) {
   .specimen {
-    height: 100dvh;
     grid-template-columns: repeat(6, minmax(0, 1fr));
-    grid-template-rows: repeat(3, minmax(0, 1fr));
     grid-template-areas:
-      "face face face face law law"
-      "face face face face law law"
-      "command command command kita kitb kitc";
+      "face face face law law law"
+      "face face face law law law"
+      "p01 p01 p02 p02 p03 p03"
+      "p04 p04 p05 p05 p06 p06"
+      "p07 p07 p08 p08 p09 p09"
+      "p10 p10 p10 note note note"
+      "kita kita kitb kitb kitc kitc"
+      "kitd kitd kitd cmd cmd cmd";
   }
-  .specimen-cell { min-height: 0; }
-  .specimen-cell-face { min-height: 0; }
-  .specimen-cell-empty { display: none; }
 }

--- a/apps/www/app/specimen.ts
+++ b/apps/www/app/specimen.ts
@@ -17,12 +17,18 @@ export const HOST = "https://raster.noord.dev";
  */
 export const KIT = ["accordion", "calendar", "field", "stepper"] as const;
 
+function normalizePath(pathname: string) {
+  const path = pathname.replace(/\/+$/, "");
+  return path === "" ? "/" : path;
+}
+
 /** Narrow exception: the flush poster has no crumb bar. */
 export function isSpecimenPath(pathname: string) {
-  return pathname === "/";
+  return normalizePath(pathname) === "/";
 }
 
 /** Flush field pages: homepage specimen and About. No crumb bar on the field. */
 export function isFieldPath(pathname: string) {
-  return pathname === "/" || pathname === "/about";
+  const path = normalizePath(pathname);
+  return path === "/" || path === "/about";
 }

--- a/apps/www/app/specimen.ts
+++ b/apps/www/app/specimen.ts
@@ -2,7 +2,8 @@
 
 export const FACE = "Inter";
 export const WORD = "Raster";
-export const LAW = "A poster you can install.";
+export const LAW = "A design system on a modular grid.";
+export const POSTER = "A poster you can install.";
 export const COMMAND = "npx @noordvc/raster-cli init";
 
 /** Public door. Do not attach DNS from this repo. */
@@ -12,11 +13,16 @@ export const HOST = "https://raster.noord.dev";
 
 /**
  * Object cells on the poster. Names from the catalog on this branch —
- * the same kit a stranger opens under /components. Not a leftover demo.
+ * the same kit a stranger opens under /components. Full objects, not crops.
  */
-export const KIT = ["button-group", "tabs", "chart"] as const;
+export const KIT = ["accordion", "calendar", "field", "stepper"] as const;
 
 /** Narrow exception: the flush poster has no crumb bar. */
 export function isSpecimenPath(pathname: string) {
   return pathname === "/";
+}
+
+/** Flush field pages: homepage specimen and About. No crumb bar on the field. */
+export function isFieldPath(pathname: string) {
+  return pathname === "/" || pathname === "/about";
 }

--- a/apps/www/components/crumb-bar.tsx
+++ b/apps/www/components/crumb-bar.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import * as React from "react";
 import { rasterComponents } from "@noordvc/raster";
-import { isSpecimenPath } from "@/app/specimen";
+import { isFieldPath, isSpecimenPath } from "@/app/specimen";
 
 interface Crumb {
   label: string;
@@ -48,8 +48,8 @@ export function CrumbBar() {
 
   const trail = trailFor(pathname);
 
-  /* Exception: the specimen path is a flush poster. No crumb bar on the field. */
-  if (isSpecimenPath(pathname)) return null;
+  /* Exception: specimen and About are flush fields. No crumb bar on the field. */
+  if (isSpecimenPath(pathname) || isFieldPath(pathname)) return null;
 
   return (
     <nav className={`rs-crumb-bar${scrolled ? " rs-crumb-bar-scrolled" : ""}`} aria-label="Breadcrumbs">

--- a/apps/www/components/docs-nav/FEATURE.md
+++ b/apps/www/components/docs-nav/FEATURE.md
@@ -2,15 +2,15 @@
 
 What it is, how to get there, what done looks like.
 
-Writers: catalog groups are `packages/core/src/schema.ts` (`rasterCategories`). Face, law, and command are `apps/www/app/specimen.ts`. The crumb bar is off on `/` (`isSpecimenPath`) so the poster stays flush.
+Writers: catalog groups are `packages/core/src/schema.ts` (`rasterCategories`). Face, law, and command are `apps/www/app/specimen.ts`. Numbered laws are `apps/www/app/specimen-laws.ts`. The crumb bar is off on `/` and `/about` (`isFieldPath`) so the field stays flush.
 
 | Surface | Route | Click path | Done |
 | --- | --- | --- | --- |
-| Specimen | `/` | Logo, or the site root | Full-viewport 204 poster. Top and left flush — no outer frame. Hero word is Raster, set in Inter. Law is “A poster you can install.” One command. Internal hairlines stay. |
+| Specimen | `/` | Logo, or the site root | Scrollable 204 field. Top and left flush — no outer frame. Hero word is Raster, set in Inter. Law is “A design system on a modular grid.” “A poster you can install.” is demoted. Numbered laws. Full kit cells (accordion, calendar, field, stepper). One command. Internal hairlines stay. |
 | Components index | `/components` | Corner → Components | First column is catalog groups from `rasterCategories`. Hover Navigation or Feedback; second column is that group's items. Secondaries are paper: no left border, no inset 184-line. The 408 module line is the only join. Catalog tiles are opaque paper (`isolation` + paper fill on the face and the description); the page grid stops at the card edge. |
 | Component | `/components/:name` | Hover the group → click the item | That page's group stays selected. Column two is not empty. |
 | Getting started | `/docs` | Corner → Docs | Short rail: Getting started, Tokens. Command is the one in `app/specimen.ts`. |
 | Tokens | `/docs/tokens` | Docs → Tokens | Same short rail. |
-| About | `/about` | Corner → About | Masthead, then Typeface, Noord, Renato Valdés Olmos, then credits from this repo’s packages. Isolated files under `app/about`. |
+| About | `/about` | Corner → About | Flush field. Noord first (AI lab, Alkmaar and Silicon Valley). Type occupies cells. Then Inter, packages, door, host, Renato Valdés Olmos, MIT. Isolated files under `app/about`. |
 
 The components rail is groups → items. It is not Getting started / Foundations / Components.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Recut `/` and `/about` from current main. Does not stack on Interfaces. Does not publish npm. Do not merge.

Preview: https://raster-git-cursor-home-about-recut-0217-renn-1738s-projects.vercel.app

## Homepage

The cropped Button group / Tabs / Charts row was the problem. The page is a scrollable 204 field: opaque paper, hairlines, flush top and left.

- Hero word stays **Raster**, Inter.
- Law is **A design system on a modular grid.**
- **A poster you can install.** stays, demoted, in its own cell.
- Ten numbered laws. Short. Sentence case. The grid is the idea. Not a lecture about 204.
- Kit is **accordion**, **calendar**, **field**, **stepper** — full objects. Cells grow. The page may scroll.
- One larger `01` as the typographic spot.

[Preview homepage hero](https://cursor.com/agents/bc-c388ce40-c2e2-4401-aa6c-4f05b2c90217/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhome-hero.png)
[Preview homepage kit cells](https://cursor.com/agents/bc-c388ce40-c2e2-4401-aa6c-4f05b2c90217/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhome-components.png)

## About

Leads with **Noord**. Noord is an AI lab (Alkmaar ↔ Silicon Valley), not a venture studio line.

Known facts only: Raster was designed and built there; Renato Valdés Olmos led design and development for Raster at Noord. Then Inter (SIL OFL 1.1, Rasmus Andersson), `@noordvc/raster` + `raster-react` + `raster-cli`, door getraster.com, host raster.noord.dev, MIT.

Type occupies cells. Same field language as the homepage. Crumb bar stays off `/about/`. No invented biography.

[Preview About Noord](https://cursor.com/agents/bc-c388ce40-c2e2-4401-aa6c-4f05b2c90217/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fabout-top.png)
[Preview About field](https://cursor.com/agents/bc-c388ce40-c2e2-4401-aa6c-4f05b2c90217/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fabout-scrolled.png)

## Verify

- CI green.
- Vercel preview READY. Opened `/` and `/about/` at full width.
- Accordion, calendar, field, and stepper are fully visible. Scrolling is fine. No crop.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c388ce40-c2e2-4401-aa6c-4f05b2c90217?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c388ce40-c2e2-4401-aa6c-4f05b2c90217&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

