### PR TITLE
Recut homepage field numerals small

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,19 @@ jobs:
           grep -q 'SpecimenKit' apps/www/app/page.tsx
           grep -q 'SpecimenPrinciples' apps/www/app/page.tsx
           grep -q 'POSTER' apps/www/app/page.tsx
+          grep -q 'specimen-index' apps/www/app/specimen-principles.tsx
+          if ! awk '/^\.specimen-n \{/,/^\}/' apps/www/app/specimen.css | grep -q 'font-size: 12px'; then
+            echo "Field numerals must stay a 12px index, not a poster numeral"
+            exit 1
+          fi
+          if awk '/^\.specimen-n \{/,/^\}/' apps/www/app/specimen.css | grep -qE 'clamp\(|[3-9][0-9]px|[0-9]+rem|[0-9]+vw'; then
+            echo "Field numerals must not scale like a poster numeral"
+            exit 1
+          fi
+          if grep -n 'specimen-cell-p01 .specimen-n' apps/www/app/specimen.css; then
+            echo "01 must not be a larger typographic spot"
+            exit 1
+          fi
           test -f apps/www/app/specimen-kit.tsx
           test -f apps/www/app/specimen-laws.ts
           if grep -nE '^[[:space:]]*height: 100dvh' apps/www/app/specimen.css; then

--- a/apps/www/app/specimen-principles.tsx
+++ b/apps/www/app/specimen-principles.tsx
@@ -9,10 +9,12 @@ export function SpecimenPrinciples() {
           className={`specimen-cell specimen-cell-principle specimen-cell-p${law.n}`}
           aria-label={`Law ${law.n}`}
         >
-          <p className="specimen-n" aria-hidden="true">
-            {law.n}
-          </p>
-          <p className="specimen-n-text">{law.text}</p>
+          <div className="specimen-index">
+            <p className="specimen-n" aria-hidden="true">
+              {law.n}
+            </p>
+            <p className="specimen-n-text">{law.text}</p>
+          </div>
         </section>
       ))}
     </>

--- a/apps/www/app/specimen.css
+++ b/apps/www/app/specimen.css
@@ -96,20 +96,22 @@
   max-width: 9em;
 }
 .specimen-cell-principle {
-  justify-content: space-between;
-  gap: 16px;
+  justify-content: flex-end;
+}
+.specimen-index {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
 }
 .specimen-n {
   margin: 0;
-  font-size: clamp(52px, 10vw, 88px);
+  flex: none;
+  font-size: 12px;
   font-weight: 600;
-  letter-spacing: -.045em;
-  line-height: .85;
+  letter-spacing: -.01em;
+  line-height: 1.3;
   font-variant-numeric: tabular-nums;
-  color: var(--text);
-}
-.specimen-cell-p01 .specimen-n {
-  font-size: clamp(72px, 14vw, 120px);
+  color: var(--text-secondary);
 }
 .specimen-n-text {
   margin: 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Recut the homepage field numerals from current main. Does not stack on Interfaces. Does not publish npm. Do not merge.

Preview: https://raster-git-cursor-small-field-numerals-1799-renn-1738s-projects.vercel.app

Renato: “lets make the numbers small.” The 01–10 marks were poster numerals (with a larger 01 as a typographic spot). They now sit as a quiet 12px index next to each sentence-case law.

Unchanged:
- Hero word **Raster**
- Tagline **A design system on a modular grid.**
- **A poster you can install.** stays demoted
- Law copy
- Grid, hairlines, flush, Inter, no radius, no shadow, no Tailwind, no Radix

CI locks the numerals at 12px and rejects the oversized 01 spot.

Informed by Renato’s recut after the homepage field merge (PR 4). Granola was not available in this run.

## Verify

- CI `test` green on `36e39ff`.
- Vercel preview READY for that SHA.
- Opened `/` on the same static export as the preview (preview itself is behind Vercel Authentication from this agent). Numbers are a quiet index; the laws are the readable thing. 01 is the same size as 02–10.

Hero, tagline, and first six laws:

[Homepage hero Raster with small 01–06 indexes next to the laws](https://cursor.com/agents/bc-c4de8423-7df8-4261-be37-c534b80a1799/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhome_hero.png)

Laws 04–10 and the demoted poster line:

[Homepage field laws 04–10 with small indexes and demoted poster line](https://cursor.com/agents/bc-c4de8423-7df8-4261-be37-c534b80a1799/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhome_field_laws.png)

Lower field: remaining laws, poster line, kit cells:

[Homepage field laws 07–10, poster line, and kit cells](https://cursor.com/agents/bc-c4de8423-7df8-4261-be37-c534b80a1799/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhome_field_laws_kit.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4de8423-7df8-4261-be37-c534b80a1799?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4de8423-7df8-4261-be37-c534b80a1799&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

