### PR TITLE
Retarget Raster packages from @noordvc to @noorddev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
             "$(printf '@%s/' 'raster')"
             "$(printf '@%s/raster' 'noord')"
             "$(printf '@%s/' 'rennvaldes')"
+            "$(printf '@%s/' 'noordvc')"
+            "$(printf '@%s/' 'noordai')"
           )
           for needle in "${needles[@]}"; do
             if grep -R -n -F "$needle" --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist --exclude-dir=.next --exclude-dir=out --exclude-dir=public --exclude=pnpm-lock.yaml .; then
@@ -68,7 +70,7 @@ jobs:
           grep -q '{WORD}' "$page"
           grep -q 'A poster you can install.' "$writer"
           grep -q 'A design system on a modular grid.' "$writer"
-          grep -q 'npx @noordvc/raster-cli init' "$writer"
+          grep -q 'npx @noorddev/raster-cli init' "$writer"
           if grep -n -E 'One ink|204 module|Crouwel|Müller-Brockmann' "$page" "$writer" apps/www/app/layout.tsx apps/www/app/social.ts; then
             echo "Homepage law must not use the old museum caption"
             exit 1
@@ -249,7 +251,7 @@ jobs:
           grep -q 'heading: "Renato Valdés Olmos"' "$facts"
           grep -q 'foundry.license' "$facts"
           grep -q 'meta.url' "$facts"
-          grep -q '@noordvc/raster' "$facts"
+          grep -q '@noorddev/raster' "$facts"
           grep -q 'type.foundry' "$facts"
           grep -q 'AI lab' "$facts"
           grep -q 'Alkmaar' "$facts"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@
 Cut 1: a stranger can install Raster after merge, npm publish, and DNS.
 
 - MIT on the code. Inter stays SIL OFL 1.1 (`packages/core/css/fonts/inter/OFL.txt`).
-- Publishable packages: `@noordvc/raster`, `@noordvc/raster-react`, `@noordvc/raster-cli` at 0.3.0. The `raster` and `noord` npm orgs are not available; the locked org is `noordvc`. Not private. Types ship in the tarball. `@noordvc/raster-react` depends on `@noordvc/raster` so CSS is not a second secret install.
+- Publishable packages: `@noorddev/raster`, `@noorddev/raster-react`, `@noorddev/raster-cli` at 0.3.0. The locked org is `noorddev`. Not private. Types ship in the tarball. `@noorddev/raster-react` depends on `@noorddev/raster` so CSS is not a second secret install.
 - Default face is vendored Inter (variable, latin + latin-ext). System sans is fallback only. Messina is off.
 - Public host is `https://raster.noord.dev`. Generated registry items, `raster-base`, and the `inter` item use that host. Dead hosts (`raster.design`, `raster-pied`, `vercel.app`) fail CI.
-- Documented CLI is `npx @noordvc/raster-cli init`. `--registry` is implemented (HTTP(S) or a local directory; also `raster.json.registry`). `init --compat` still writes 0.1 class names.
+- Documented CLI is `npx @noorddev/raster-cli init`. `--registry` is implemented (HTTP(S) or a local directory; also `raster.json.registry`). `init --compat` still writes 0.1 class names.
 - Dropped leftover `raster.design` copy and the `/api/raster/tokens` + `/api/mcp` pointers. Those routes do not exist on this static export.
 - Docs first page and getting started show the one command and Inter.
 - Everyday shadcn/ui primitives now install Raster-style: button group, drawer, empty, field, form (React), input group, item, label, native select, sidebar, spinner, toggle group. Catalog completeness, not a clone. Deferred: sonner (needs the sonner widget), direction (RTL helper, not a primitive), and the AI chat set (attachment, bubble, marker, message, message-scroller) which depend on Radix or `@shadcn/react`.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ This repo contains the tokens, CSS, React components, registry, CLI, and documen
 
 | Path | Package | Contents |
 |---|---|---|
-| `packages/core` | `@noordvc/raster` | Tokens, per-component CSS, vendored Inter, the typed registry, and the build that generates `raster.css`, `tokens.css`, the token JSON, and the 0.1 compat layer |
-| `packages/react` | `@noordvc/raster-react` | React components styled by `@noordvc/raster` CSS (`@noordvc/raster-react` depends on `@noordvc/raster`) |
-| `packages/cli` | `@noordvc/raster-cli` | `npx @noordvc/raster-cli init` / `add` / `list` / `tokens`. Bundles the registry; works offline |
+| `packages/core` | `@noorddev/raster` | Tokens, per-component CSS, vendored Inter, the typed registry, and the build that generates `raster.css`, `tokens.css`, the token JSON, and the 0.1 compat layer |
+| `packages/react` | `@noorddev/raster-react` | React components styled by `@noorddev/raster` CSS (`@noorddev/raster-react` depends on `@noorddev/raster`) |
+| `packages/cli` | `@noorddev/raster-cli` | `npx @noorddev/raster-cli init` / `add` / `list` / `tokens`. Bundles the registry; works offline |
 | `registry/` | | Generated registry items in the shadcn registry-item schema |
 | `apps/www` | | Documentation site: gallery, per-component docs, tokens, served registry |
 
@@ -30,20 +30,20 @@ This repo contains the tokens, CSS, React components, registry, CLI, and documen
 **CLI.**
 
 ```sh
-npx @noordvc/raster-cli init            # writes styles/raster.css, Inter, and raster.json
-npx @noordvc/raster-cli add button dialog
+npx @noorddev/raster-cli init            # writes styles/raster.css, Inter, and raster.json
+npx @noorddev/raster-cli add button dialog
 ```
 
 `add` copies React source into `components/raster/`. Registry dependencies install with it. CSS-only components need no code; the classes are in raster.css.
 
 `init --compat` also writes the 0.1 class-name layer. `init --registry <url>` (or `raster.json.registry`) points `add` at a remote registry for out-of-band updates.
 
-**Plain CSS.** Import `@noordvc/raster/css` (or link the file the CLI wrote) and use the `rs-*` classes. Set `data-theme="dark"` on the root element for the dark scheme.
+**Plain CSS.** Import `@noorddev/raster/css` (or link the file the CLI wrote) and use the `rs-*` classes. Set `data-theme="dark"` on the root element for the dark scheme.
 
 **Tokens.**
 
 ```ts
-import { rasterTokens } from "@noordvc/raster";
+import { rasterTokens } from "@noorddev/raster";
 rasterTokens.color.light.paper; // "#FAF8F2"
 ```
 
@@ -91,7 +91,7 @@ Inter, SIL OFL 1.1. Variable, latin + latin-ext, vendored next to the CSS. Syste
 
 ## Coming from 0.1
 
-0.2 renamed every class to the `rs-` prefix and scoped table styles to `.rs-table`. Sites on the 0.1 names keep working by linking the generated `css/raster-compat.css` after `raster.css`, or via `npx @noordvc/raster-cli init --compat`. The rename map is `packages/core/src/legacy.ts`.
+0.2 renamed every class to the `rs-` prefix and scoped table styles to `.rs-table`. Sites on the 0.1 names keep working by linking the generated `css/raster-compat.css` after `raster.css`, or via `npx @noorddev/raster-cli init --compat`. The rename map is `packages/core/src/legacy.ts`.
 
 ---
 

--- a/apps/www/app/about/facts.ts
+++ b/apps/www/app/about/facts.ts
@@ -12,7 +12,7 @@
  */
 
 import { DOOR, LAW, WORD } from "../specimen";
-import { rasterTokens } from "@noordvc/raster";
+import { rasterTokens } from "@noorddev/raster";
 
 export const word = WORD;
 export const law = LAW;
@@ -37,8 +37,8 @@ export const noord = {
   who: "Renato Valdés Olmos led design and development for Raster at Noord.",
   door: DOOR,
   host: rasterTokens.meta.url,
-  packages: ["@noordvc/raster", "@noordvc/raster-react", "@noordvc/raster-cli"] as const,
-  command: "npx @noordvc/raster-cli init",
+  packages: ["@noorddev/raster", "@noorddev/raster-react", "@noorddev/raster-cli"] as const,
+  command: "npx @noorddev/raster-cli init",
 };
 
 export const person = {

--- a/apps/www/app/components/[name]/page.tsx
+++ b/apps/www/app/components/[name]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { rasterComponents } from "@noordvc/raster";
+import { rasterComponents } from "@noorddev/raster";
 import { CodeBlock } from "@/components/code-block";
 import { DocsNav } from "@/components/docs-nav";
 import { InAction } from "@/components/examples/scene";
@@ -480,7 +480,7 @@ export default async function ComponentPage({
         <InAction name={component.name} />
 
         <h2 className="section-label">Install</h2>
-        <CodeBlock code={`npx @noordvc/raster-cli add ${component.name}`} />
+        <CodeBlock code={`npx @noorddev/raster-cli add ${component.name}`} />
 
         <h2 className="section-label">Markup</h2>
         <CodeBlock code={component.snippet} />

--- a/apps/www/app/components/page.tsx
+++ b/apps/www/app/components/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import type { Metadata } from "next";
-import { rasterCategories, rasterComponents } from "@noordvc/raster";
+import { rasterCategories, rasterComponents } from "@noorddev/raster";
 import { DocsNav } from "@/components/docs-nav";
 import { Preview } from "@/components/preview";
 

--- a/apps/www/app/docs/page.tsx
+++ b/apps/www/app/docs/page.tsx
@@ -22,7 +22,7 @@ export default function DocsPage() {
           </header>
 
         <h2 className="section-label">1. Initialize</h2>
-        <CodeBlock code={`npx @noordvc/raster-cli init`} />
+        <CodeBlock code={`npx @noorddev/raster-cli init`} />
         <p className="rs-t-body">
           Writes <code className="rs-code">styles/raster.css</code> (tokens, Inter, base
           styles, component classes), the Inter files, and{" "}
@@ -32,7 +32,7 @@ export default function DocsPage() {
         </p>
 
         <h2 className="section-label">2. Add components</h2>
-        <CodeBlock code={`npx @noordvc/raster-cli add button dialog switch`} />
+        <CodeBlock code={`npx @noorddev/raster-cli add button dialog switch`} />
         <p className="rs-t-body">
           Copies React source into <code className="rs-code">components/raster/</code>.
           Registry dependencies install with it; dialog pulls button. CSS-only components need
@@ -55,7 +55,7 @@ export default function DocsPage() {
         </p>
 
         <h2 className="section-label">Coming from Raster 0.1</h2>
-        <CodeBlock code={`npx @noordvc/raster-cli init --compat`} />
+        <CodeBlock code={`npx @noorddev/raster-cli init --compat`} />
         <p className="rs-t-body">
           0.2 renamed every class to the <code className="rs-code">rs-</code> prefix. The
           compat flag also writes <code className="rs-code">raster-compat.css</code>, which

--- a/apps/www/app/docs/tokens/page.tsx
+++ b/apps/www/app/docs/tokens/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { concentricInner, rasterTokens } from "@noordvc/raster";
+import { concentricInner, rasterTokens } from "@noorddev/raster";
 import { CodeBlock } from "@/components/code-block";
 import { DocsNav } from "@/components/docs-nav";
 
@@ -62,7 +62,7 @@ export default function TokensPage() {
           corners concentric: inner = {radius.concentric}.
         </p>
         <CodeBlock
-          code={`import { concentricInner, concentricOuter } from "@noordvc/raster";
+          code={`import { concentricInner, concentricOuter } from "@noorddev/raster";
 
 concentricInner(28, 16); // ${concentricInner(28, 16)}
 concentricOuter(12, 16); // 28
@@ -72,14 +72,14 @@ concentricOuter(12, 16); // 28
 
         <h2 className="section-label">Programmatic access</h2>
         <CodeBlock
-          code={`import { rasterTokens } from "@noordvc/raster";
+          code={`import { rasterTokens } from "@noorddev/raster";
 
 rasterTokens.color.light.paper; // "${color.light.paper}"
 rasterTokens.grid.module;       // ${grid.module}
 
 // or over the wire
 // GET https://raster.noord.dev/r/index.json
-// npx @noordvc/raster-cli tokens`}
+// npx @noorddev/raster-cli tokens`}
         />
         </main>
       </div>

--- a/apps/www/app/interfaces/ai-tool/board.tsx
+++ b/apps/www/app/interfaces/ai-tool/board.tsx
@@ -17,7 +17,7 @@ import {
   TabPanel,
   Tabs,
   Textarea,
-} from "@noordvc/raster-react";
+} from "@noorddev/raster-react";
 
 const SHEETS = [
   { href: "#brief", label: "Brief", current: true },

--- a/apps/www/app/interfaces/dashboard/board.tsx
+++ b/apps/www/app/interfaces/dashboard/board.tsx
@@ -21,7 +21,7 @@ import {
   TabPanel,
   Tabs,
   ToggleGroup,
-} from "@noordvc/raster-react";
+} from "@noorddev/raster-react";
 
 const DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 const SHEETS = [12, 18, 15, 26, 24, 11, 9];

--- a/apps/www/app/interfaces/delivery/board.tsx
+++ b/apps/www/app/interfaces/delivery/board.tsx
@@ -13,7 +13,7 @@ import {
   Item,
   NavigationMenu,
   ToggleGroup,
-} from "@noordvc/raster-react";
+} from "@noorddev/raster-react";
 
 const PLACES = [
   { name: "De Buren", kind: "Kitchen", rating: "4.8", time: "22 min", area: "Alkmaar", tag: "Open" },

--- a/apps/www/app/interfaces/fleet/board.tsx
+++ b/apps/www/app/interfaces/fleet/board.tsx
@@ -6,7 +6,7 @@ import {
   Badge,
   Item,
   ScrollArea,
-} from "@noordvc/raster-react";
+} from "@noorddev/raster-react";
 import { FleetMap } from "./map";
 
 const ACTIVE = [

--- a/apps/www/app/interfaces/slack/board.tsx
+++ b/apps/www/app/interfaces/slack/board.tsx
@@ -14,7 +14,7 @@ import {
   SidebarLabel,
   SidebarNav,
   Textarea,
-} from "@noordvc/raster-react";
+} from "@noorddev/raster-react";
 
 type Kind = "person" | "agent";
 

--- a/apps/www/app/interfaces/threads/board.tsx
+++ b/apps/www/app/interfaces/threads/board.tsx
@@ -19,7 +19,7 @@ import {
   TabList,
   TabPanel,
   Tabs,
-} from "@noordvc/raster-react";
+} from "@noorddev/raster-react";
 
 type Post = {
   id: string;

--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";
-import "@noordvc/raster/css";
+import "@noorddev/raster/css";
 import "./site.css";
 import "@/components/examples/use.css";
 import { CrumbBar } from "@/components/crumb-bar";

--- a/apps/www/app/specimen-kit.tsx
+++ b/apps/www/app/specimen-kit.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { rasterComponents } from "@noordvc/raster";
+import { rasterComponents } from "@noorddev/raster";
 import { Preview } from "@/components/preview";
 import { KIT } from "./specimen";
 

--- a/apps/www/app/specimen.ts
+++ b/apps/www/app/specimen.ts
@@ -4,7 +4,7 @@ export const FACE = "Inter";
 export const WORD = "Raster";
 export const LAW = "A design system on a modular grid.";
 export const POSTER = "A poster you can install.";
-export const COMMAND = "npx @noordvc/raster-cli init";
+export const COMMAND = "npx @noorddev/raster-cli init";
 
 /** Public door. Do not attach DNS from this repo. */
 export const DOOR = "https://getraster.com";

--- a/apps/www/components/crumb-bar.tsx
+++ b/apps/www/components/crumb-bar.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import * as React from "react";
-import { rasterComponents } from "@noordvc/raster";
+import { rasterComponents } from "@noorddev/raster";
 import { interfaceBySlug } from "@/app/interfaces/catalog";
 import { isFieldPath, isSpecimenPath } from "@/app/specimen";
 

--- a/apps/www/components/docs-nav/index.tsx
+++ b/apps/www/components/docs-nav/index.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import * as React from "react";
-import { rasterCategories, rasterComponents, type RasterCategory } from "@noordvc/raster";
+import { rasterCategories, rasterComponents, type RasterCategory } from "@noorddev/raster";
 import { MobileToc } from "@/components/toc-mobile";
 import "./docs-nav.css";
 

--- a/apps/www/components/examples/accordion/use.tsx
+++ b/apps/www/components/examples/accordion/use.tsx
@@ -1,4 +1,4 @@
-import { Accordion, AccordionItem } from "@noordvc/raster-react";
+import { Accordion, AccordionItem } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/alert-dialog/use.tsx
+++ b/apps/www/components/examples/alert-dialog/use.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { AlertDialog, AlertDialogActions, AlertDialogBody, AlertDialogTitle, Button } from "@noordvc/raster-react";
+import { AlertDialog, AlertDialogActions, AlertDialogBody, AlertDialogTitle, Button } from "@noorddev/raster-react";
 
 export function Use() {
   const [open, setOpen] = React.useState(false);

--- a/apps/www/components/examples/alert/use.tsx
+++ b/apps/www/components/examples/alert/use.tsx
@@ -1,4 +1,4 @@
-import { Alert } from "@noordvc/raster-react";
+import { Alert } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/area-chart/use.tsx
+++ b/apps/www/components/examples/area-chart/use.tsx
@@ -1,4 +1,4 @@
-import { AreaChart } from "@noordvc/raster-react";
+import { AreaChart } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/aspect-ratio/use.tsx
+++ b/apps/www/components/examples/aspect-ratio/use.tsx
@@ -1,4 +1,4 @@
-import { AspectRatio } from "@noordvc/raster-react";
+import { AspectRatio } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/avatar/use.tsx
+++ b/apps/www/components/examples/avatar/use.tsx
@@ -1,4 +1,4 @@
-import { Avatar, AvatarRow } from "@noordvc/raster-react";
+import { Avatar, AvatarRow } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/badge/use.tsx
+++ b/apps/www/components/examples/badge/use.tsx
@@ -1,4 +1,4 @@
-import { Badge } from "@noordvc/raster-react";
+import { Badge } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/bar-chart/use.tsx
+++ b/apps/www/components/examples/bar-chart/use.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { BarChart, ToggleGroup } from "@noordvc/raster-react";
+import { BarChart, ToggleGroup } from "@noorddev/raster-react";
 
 const CITIES = [
   { label: "Alkmaar", value: 42 },

--- a/apps/www/components/examples/breadcrumbs/use.tsx
+++ b/apps/www/components/examples/breadcrumbs/use.tsx
@@ -1,4 +1,4 @@
-import { Breadcrumbs } from "@noordvc/raster-react";
+import { Breadcrumbs } from "@noorddev/raster-react";
 
 /** A masthead trail. One ink line, not a web crumb. */
 export function Use() {

--- a/apps/www/components/examples/button-group/use.tsx
+++ b/apps/www/components/examples/button-group/use.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonGroup } from "@noordvc/raster-react";
+import { Button, ButtonGroup } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/button/use.tsx
+++ b/apps/www/components/examples/button/use.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@noordvc/raster-react";
+import { Button } from "@noorddev/raster-react";
 
 /** Press ticket: one primary, one ghost. The sheet is the product. */
 export function Use() {

--- a/apps/www/components/examples/calendar/use.tsx
+++ b/apps/www/components/examples/calendar/use.tsx
@@ -1,4 +1,4 @@
-import { Calendar } from "@noordvc/raster-react";
+import { Calendar } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/card/use.tsx
+++ b/apps/www/components/examples/card/use.tsx
@@ -1,4 +1,4 @@
-import { Card, CardBody, CardLabel, CardTitle } from "@noordvc/raster-react";
+import { Card, CardBody, CardLabel, CardTitle } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/carousel/use.tsx
+++ b/apps/www/components/examples/carousel/use.tsx
@@ -1,4 +1,4 @@
-import { Carousel } from "@noordvc/raster-react";
+import { Carousel } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/chart/use.tsx
+++ b/apps/www/components/examples/chart/use.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { LineChart, ToggleGroup } from "@noordvc/raster-react";
+import { LineChart, ToggleGroup } from "@noorddev/raster-react";
 
 const DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri"];
 const SHEETS = [12, 18, 15, 26, 24];

--- a/apps/www/components/examples/checkbox/use.tsx
+++ b/apps/www/components/examples/checkbox/use.tsx
@@ -1,4 +1,4 @@
-import { Checkbox } from "@noordvc/raster-react";
+import { Checkbox } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/collapsible/use.tsx
+++ b/apps/www/components/examples/collapsible/use.tsx
@@ -1,4 +1,4 @@
-import { Collapsible } from "@noordvc/raster-react";
+import { Collapsible } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/combobox/use.tsx
+++ b/apps/www/components/examples/combobox/use.tsx
@@ -1,4 +1,4 @@
-import { Combobox } from "@noordvc/raster-react";
+import { Combobox } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/command/use.tsx
+++ b/apps/www/components/examples/command/use.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Button, CommandDialog } from "@noordvc/raster-react";
+import { Button, CommandDialog } from "@noorddev/raster-react";
 
 export function Use() {
   const [open, setOpen] = React.useState(false);

--- a/apps/www/components/examples/concentric-radius/use.tsx
+++ b/apps/www/components/examples/concentric-radius/use.tsx
@@ -1,4 +1,4 @@
-import { Nest, NestInner } from "@noordvc/raster-react";
+import { Nest, NestInner } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/context-menu/use.tsx
+++ b/apps/www/components/examples/context-menu/use.tsx
@@ -1,4 +1,4 @@
-import { ContextMenu } from "@noordvc/raster-react";
+import { ContextMenu } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/data-table/use.tsx
+++ b/apps/www/components/examples/data-table/use.tsx
@@ -1,4 +1,4 @@
-import { DataTable } from "@noordvc/raster-react";
+import { DataTable } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/date-picker/use.tsx
+++ b/apps/www/components/examples/date-picker/use.tsx
@@ -1,4 +1,4 @@
-import { DatePicker } from "@noordvc/raster-react";
+import { DatePicker } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/dialog/use.tsx
+++ b/apps/www/components/examples/dialog/use.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Button, Dialog, DialogActions, DialogBody, DialogTitle } from "@noordvc/raster-react";
+import { Button, Dialog, DialogActions, DialogBody, DialogTitle } from "@noorddev/raster-react";
 
 export function Use() {
   const [open, setOpen] = React.useState(false);

--- a/apps/www/components/examples/donut/use.tsx
+++ b/apps/www/components/examples/donut/use.tsx
@@ -1,4 +1,4 @@
-import { Donut, Share } from "@noordvc/raster-react";
+import { Donut, Share } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/drawer/use.tsx
+++ b/apps/www/components/examples/drawer/use.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Button, Drawer, DrawerBody, DrawerTitle } from "@noordvc/raster-react";
+import { Button, Drawer, DrawerBody, DrawerTitle } from "@noorddev/raster-react";
 
 export function Use() {
   const [open, setOpen] = React.useState(false);

--- a/apps/www/components/examples/dropdown-menu/use.tsx
+++ b/apps/www/components/examples/dropdown-menu/use.tsx
@@ -1,4 +1,4 @@
-import { DropdownMenu } from "@noordvc/raster-react";
+import { DropdownMenu } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/empty/use.tsx
+++ b/apps/www/components/examples/empty/use.tsx
@@ -1,4 +1,4 @@
-import { Button, Empty } from "@noordvc/raster-react";
+import { Button, Empty } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/field/use.tsx
+++ b/apps/www/components/examples/field/use.tsx
@@ -1,4 +1,4 @@
-import { Field, FieldHint, FieldLabel } from "@noordvc/raster-react";
+import { Field, FieldHint, FieldLabel } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/form/use.tsx
+++ b/apps/www/components/examples/form/use.tsx
@@ -1,4 +1,4 @@
-import { Button, Field, FieldLabel, Form } from "@noordvc/raster-react";
+import { Button, Field, FieldLabel, Form } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/histogram/use.tsx
+++ b/apps/www/components/examples/histogram/use.tsx
@@ -1,4 +1,4 @@
-import { Histogram } from "@noordvc/raster-react";
+import { Histogram } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/hover-card/use.tsx
+++ b/apps/www/components/examples/hover-card/use.tsx
@@ -1,4 +1,4 @@
-import { HoverCard } from "@noordvc/raster-react";
+import { HoverCard } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/inline-form/use.tsx
+++ b/apps/www/components/examples/inline-form/use.tsx
@@ -1,4 +1,4 @@
-import { InlineForm } from "@noordvc/raster-react";
+import { InlineForm } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/input-group/use.tsx
+++ b/apps/www/components/examples/input-group/use.tsx
@@ -1,4 +1,4 @@
-import { InputAddon, InputGroup } from "@noordvc/raster-react";
+import { InputAddon, InputGroup } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/input-otp/use.tsx
+++ b/apps/www/components/examples/input-otp/use.tsx
@@ -1,4 +1,4 @@
-import { InputOTP } from "@noordvc/raster-react";
+import { InputOTP } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/input/use.tsx
+++ b/apps/www/components/examples/input/use.tsx
@@ -1,4 +1,4 @@
-import { Input } from "@noordvc/raster-react";
+import { Input } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/item/use.tsx
+++ b/apps/www/components/examples/item/use.tsx
@@ -1,4 +1,4 @@
-import { Item } from "@noordvc/raster-react";
+import { Item } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/kbd/use.tsx
+++ b/apps/www/components/examples/kbd/use.tsx
@@ -1,4 +1,4 @@
-import { Kbd } from "@noordvc/raster-react";
+import { Kbd } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/label/use.tsx
+++ b/apps/www/components/examples/label/use.tsx
@@ -1,4 +1,4 @@
-import { Label } from "@noordvc/raster-react";
+import { Label } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/menubar/use.tsx
+++ b/apps/www/components/examples/menubar/use.tsx
@@ -1,4 +1,4 @@
-import { Menubar } from "@noordvc/raster-react";
+import { Menubar } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/native-select/use.tsx
+++ b/apps/www/components/examples/native-select/use.tsx
@@ -1,4 +1,4 @@
-import { NativeSelect } from "@noordvc/raster-react";
+import { NativeSelect } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/navigation-menu/use.tsx
+++ b/apps/www/components/examples/navigation-menu/use.tsx
@@ -1,4 +1,4 @@
-import { NavigationMenu } from "@noordvc/raster-react";
+import { NavigationMenu } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/pagination/use.tsx
+++ b/apps/www/components/examples/pagination/use.tsx
@@ -1,4 +1,4 @@
-import { Pagination } from "@noordvc/raster-react";
+import { Pagination } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/popover/use.tsx
+++ b/apps/www/components/examples/popover/use.tsx
@@ -1,4 +1,4 @@
-import { Popover, PopoverBody, PopoverTitle } from "@noordvc/raster-react";
+import { Popover, PopoverBody, PopoverTitle } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/progress/use.tsx
+++ b/apps/www/components/examples/progress/use.tsx
@@ -1,4 +1,4 @@
-import { Progress } from "@noordvc/raster-react";
+import { Progress } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/radio/use.tsx
+++ b/apps/www/components/examples/radio/use.tsx
@@ -1,4 +1,4 @@
-import { Radio, RadioGroup } from "@noordvc/raster-react";
+import { Radio, RadioGroup } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/resizable/use.tsx
+++ b/apps/www/components/examples/resizable/use.tsx
@@ -1,4 +1,4 @@
-import { Split } from "@noordvc/raster-react";
+import { Split } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/scatter-chart/use.tsx
+++ b/apps/www/components/examples/scatter-chart/use.tsx
@@ -1,4 +1,4 @@
-import { ScatterChart } from "@noordvc/raster-react";
+import { ScatterChart } from "@noorddev/raster-react";
 
 const MARKS = [
   { x: 12, y: 18, label: "Alkmaar", group: "Press" },

--- a/apps/www/components/examples/scroll-area/use.tsx
+++ b/apps/www/components/examples/scroll-area/use.tsx
@@ -1,4 +1,4 @@
-import { ScrollArea } from "@noordvc/raster-react";
+import { ScrollArea } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/select/use.tsx
+++ b/apps/www/components/examples/select/use.tsx
@@ -1,4 +1,4 @@
-import { Select } from "@noordvc/raster-react";
+import { Select } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/separator/use.tsx
+++ b/apps/www/components/examples/separator/use.tsx
@@ -1,4 +1,4 @@
-import { Separator } from "@noordvc/raster-react";
+import { Separator } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/sheet/use.tsx
+++ b/apps/www/components/examples/sheet/use.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Button, Sheet, SheetBody, SheetTitle } from "@noordvc/raster-react";
+import { Button, Sheet, SheetBody, SheetTitle } from "@noorddev/raster-react";
 
 export function Use() {
   const [open, setOpen] = React.useState(false);

--- a/apps/www/components/examples/sidebar/use.tsx
+++ b/apps/www/components/examples/sidebar/use.tsx
@@ -1,4 +1,4 @@
-import { Sidebar, SidebarFoot, SidebarHead, SidebarItem, SidebarLabel, SidebarNav } from "@noordvc/raster-react";
+import { Sidebar, SidebarFoot, SidebarHead, SidebarItem, SidebarLabel, SidebarNav } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/skeleton/use.tsx
+++ b/apps/www/components/examples/skeleton/use.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from "@noordvc/raster-react";
+import { Skeleton } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/slider/use.tsx
+++ b/apps/www/components/examples/slider/use.tsx
@@ -1,4 +1,4 @@
-import { Slider } from "@noordvc/raster-react";
+import { Slider } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/small-multiples/use.tsx
+++ b/apps/www/components/examples/small-multiples/use.tsx
@@ -1,4 +1,4 @@
-import { SmallMultiples } from "@noordvc/raster-react";
+import { SmallMultiples } from "@noorddev/raster-react";
 
 const DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri"];
 

--- a/apps/www/components/examples/spinner/use.tsx
+++ b/apps/www/components/examples/spinner/use.tsx
@@ -1,4 +1,4 @@
-import { Spinner } from "@noordvc/raster-react";
+import { Spinner } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/stepper/use.tsx
+++ b/apps/www/components/examples/stepper/use.tsx
@@ -1,4 +1,4 @@
-import { Stepper } from "@noordvc/raster-react";
+import { Stepper } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/switch/use.tsx
+++ b/apps/www/components/examples/switch/use.tsx
@@ -1,4 +1,4 @@
-import { Switch } from "@noordvc/raster-react";
+import { Switch } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/tabs/use.tsx
+++ b/apps/www/components/examples/tabs/use.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Tab, TabList, TabPanel, Tabs } from "@noordvc/raster-react";
+import { Tab, TabList, TabPanel, Tabs } from "@noorddev/raster-react";
 
 /** An issue board. The panel fades in — 0.22s, ease, no bounce. */
 export function Use() {

--- a/apps/www/components/examples/textarea/use.tsx
+++ b/apps/www/components/examples/textarea/use.tsx
@@ -1,4 +1,4 @@
-import { Textarea } from "@noordvc/raster-react";
+import { Textarea } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/theme-toggle/use.tsx
+++ b/apps/www/components/examples/theme-toggle/use.tsx
@@ -1,4 +1,4 @@
-import { ThemeToggle } from "@noordvc/raster-react";
+import { ThemeToggle } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/toast/use.tsx
+++ b/apps/www/components/examples/toast/use.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button, toast, Toaster } from "@noordvc/raster-react";
+import { Button, toast, Toaster } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/toggle-group/use.tsx
+++ b/apps/www/components/examples/toggle-group/use.tsx
@@ -1,4 +1,4 @@
-import { ToggleGroup } from "@noordvc/raster-react";
+import { ToggleGroup } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/toggle/use.tsx
+++ b/apps/www/components/examples/toggle/use.tsx
@@ -1,4 +1,4 @@
-import { Toggle } from "@noordvc/raster-react";
+import { Toggle } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/examples/tooltip/use.tsx
+++ b/apps/www/components/examples/tooltip/use.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from "@noordvc/raster-react";
+import { Tooltip } from "@noorddev/raster-react";
 
 export function Use() {
   return (

--- a/apps/www/components/preview.tsx
+++ b/apps/www/components/preview.tsx
@@ -99,7 +99,7 @@ import {
   TabList,
   TabPanel,
   Tabs,
-} from "@noordvc/raster-react";
+} from "@noorddev/raster-react";
 
 function DialogDemo() {
   const [open, setOpen] = React.useState(false);

--- a/apps/www/next.config.mjs
+++ b/apps/www/next.config.mjs
@@ -2,7 +2,7 @@
 const nextConfig = {
   output: "export",
   trailingSlash: true,
-  transpilePackages: ["@noordvc/raster", "@noordvc/raster-react", "three"],
+  transpilePackages: ["@noorddev/raster", "@noorddev/raster-react", "three"],
 };
 
 export default nextConfig;

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -13,8 +13,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@noordvc/raster": "workspace:*",
-    "@noordvc/raster-react": "workspace:*",
+    "@noorddev/raster": "workspace:*",
+    "@noorddev/raster-react": "workspace:*",
     "next": "^15.1.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/apps/www/scripts/copy-registry.mjs
+++ b/apps/www/scripts/copy-registry.mjs
@@ -8,7 +8,7 @@ const src = fileURLToPath(new URL("../../../registry", import.meta.url));
 const dest = fileURLToPath(new URL("../public/r", import.meta.url));
 
 if (!existsSync(src)) {
-  console.error("registry/ not found — run: pnpm --filter @noordvc/raster build:registry");
+  console.error("registry/ not found — run: pnpm --filter @noorddev/raster build:registry");
   process.exit(1);
 }
 mkdirSync(dest, { recursive: true });

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build": "pnpm -r --filter './packages/*' build",
-    "build:registry": "pnpm --filter @noordvc/raster build:registry",
+    "build:registry": "pnpm --filter @noorddev/raster build:registry",
     "test": "pnpm -r --filter './packages/*' test",
     "typecheck": "pnpm -r --filter './packages/*' typecheck",
     "dev": "pnpm --filter www dev"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@noordvc/raster-cli",
+  "name": "@noorddev/raster-cli",
   "version": "0.3.0",
-  "description": "The Raster CLI — install the monochrome design system into any project: npx @noordvc/raster-cli init, npx @noordvc/raster-cli add <component>.",
+  "description": "The Raster CLI — install the monochrome design system into any project: npx @noorddev/raster-cli init, npx @noorddev/raster-cli add <component>.",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -20,12 +20,12 @@
     "dist"
   ],
   "scripts": {
-    "build": "pnpm --filter @noordvc/raster build:css && pnpm --filter @noordvc/raster build:registry && tsup && node scripts/copy-fonts.mjs",
+    "build": "pnpm --filter @noorddev/raster build:css && pnpm --filter @noorddev/raster build:registry && tsup && node scripts/copy-fonts.mjs",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@noordvc/raster": "workspace:*",
+    "@noorddev/raster": "workspace:*",
     "@types/node": "^26.1.1",
     "tsup": "^8.3.5",
     "typescript": "^5.7.3",

--- a/packages/cli/scripts/copy-fonts.mjs
+++ b/packages/cli/scripts/copy-fonts.mjs
@@ -1,5 +1,5 @@
 // Copy vendored Inter files next to the bundled CLI so `init` can
-// write them beside raster.css without reaching back into @noordvc/raster.
+// write them beside raster.css without reaching back into @noorddev/raster.
 import { cpSync, mkdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,14 +2,14 @@ import { add, init, list, snippetFor, tokensJson } from "./lib";
 
 const VERSION = "0.3.0";
 
-const HELP = `@noordvc/raster-cli ${VERSION}, the monochrome design system
+const HELP = `@noorddev/raster-cli ${VERSION}, the monochrome design system
 
 Usage
-  npx @noordvc/raster-cli init [--css-dir <dir>] [--components-dir <dir>] [--compat] [--registry <url>] [--overwrite]
-  npx @noordvc/raster-cli add <component...> [--overwrite] [--registry <url>]
-  npx @noordvc/raster-cli list
-  npx @noordvc/raster-cli tokens
-  npx @noordvc/raster-cli help
+  npx @noorddev/raster-cli init [--css-dir <dir>] [--components-dir <dir>] [--compat] [--registry <url>] [--overwrite]
+  npx @noorddev/raster-cli add <component...> [--overwrite] [--registry <url>]
+  npx @noorddev/raster-cli list
+  npx @noorddev/raster-cli tokens
+  npx @noorddev/raster-cli help
 
 Commands
   init      Write raster.css, Inter (SIL OFL 1.1), and raster.json.
@@ -77,21 +77,21 @@ Next steps
        <link rel="stylesheet" href="/${results[0]!.path}" />
   2. Dark scheme: set data-theme="dark" on <html>.
   3. Inter is bundled (SIL OFL 1.1). System sans is fallback only.
-  4. Add components:  npx @noordvc/raster-cli add button dialog
+  4. Add components:  npx @noorddev/raster-cli add button dialog
 `);
       break;
     }
 
     case "add": {
       if (positional.length === 0) {
-        console.error("Nothing to add. Usage: npx @noordvc/raster-cli add <component...>   (see: npx @noordvc/raster-cli list)");
+        console.error("Nothing to add. Usage: npx @noorddev/raster-cli add <component...>   (see: npx @noorddev/raster-cli list)");
         process.exit(1);
       }
       const { outcomes, unknown } = await add(cwd, positional, {
         overwrite: Boolean(flags["overwrite"]),
         registry: registryFlag(flags),
       });
-      for (const name of unknown) console.error(`✗ unknown component "${name}". See: npx @noordvc/raster-cli list`);
+      for (const name of unknown) console.error(`✗ unknown component "${name}". See: npx @noorddev/raster-cli list`);
       for (const outcome of outcomes) {
         if (outcome.cssOnly) {
           console.log(`${outcome.item.title} (${outcome.item.name}) is CSS-only; already styled by raster.css.`);

--- a/packages/cli/src/lib.ts
+++ b/packages/cli/src/lib.ts
@@ -11,7 +11,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { rasterComponents, rasterTokens } from "@noordvc/raster";
+import { rasterComponents, rasterTokens } from "@noorddev/raster";
 import bundle from "../../../registry/bundle.json" with { type: "json" };
 
 const rasterCss: string = (bundle as { css: { raster: string } }).css.raster;
@@ -88,7 +88,7 @@ export function resolveFontsDir(): string {
   ];
   const found = candidates.find((dir) => existsSync(join(dir, "OFL.txt")));
   if (!found) {
-    throw new Error("Raster Inter files not found. Rebuild @noordvc/raster-cli (copy-fonts) or check packages/core/css/fonts/inter.");
+    throw new Error("Raster Inter files not found. Rebuild @noorddev/raster-cli (copy-fonts) or check packages/core/css/fonts/inter.");
   }
   return found;
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@noordvc/raster",
+  "name": "@noorddev/raster",
   "version": "0.3.0",
   "description": "Raster core — design tokens, component registry, and CSS. Monochrome, CSS-first, zero dependencies.",
   "license": "MIT",

--- a/packages/core/scripts/build-registry.mjs
+++ b/packages/core/scripts/build-registry.mjs
@@ -2,7 +2,7 @@
 //
 //   registry/index.json    shadcn-compatible registry index (no file contents)
 //   registry/<name>.json   shadcn-compatible registry-item, contents inlined
-//   registry/bundle.json   every item with contents, consumed by @noordvc/raster-cli
+//   registry/bundle.json   every item with contents, consumed by @noorddev/raster-cli
 //
 // Components install two ways: through the raster CLI (bundles this
 // output), or through `npx shadcn add <url>/r/<name>.json` from any

--- a/packages/core/src/tokens.ts
+++ b/packages/core/src/tokens.ts
@@ -1,7 +1,7 @@
 /**
  * Raster design tokens: the single source of truth for the design system.
  * CSS custom properties, the token JSON, and the docs site all generate
- * from this file. Tokens ship in @noordvc/raster and `npx @noordvc/raster-cli tokens`.
+ * from this file. Tokens ship in @noorddev/raster and `npx @noorddev/raster-cli tokens`.
  */
 
 export const rasterTokens = {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@noordvc/raster-react",
+  "name": "@noorddev/raster-react",
   "version": "0.3.0",
-  "description": "Raster React components — accessible, zero-dependency, styled by @noordvc/raster CSS.",
+  "description": "Raster React components — accessible, zero-dependency, styled by @noorddev/raster CSS.",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -33,10 +33,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@noordvc/raster": "workspace:^"
+    "@noorddev/raster": "workspace:^"
   },
   "peerDependencies": {
-    "@noordvc/raster": ">=0.3.0",
+    "@noorddev/raster": ">=0.3.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -6,5 +6,5 @@ export default defineConfig({
   dts: true,
   sourcemap: true,
   clean: true,
-  external: ["react", "react-dom", "@noordvc/raster"],
+  external: ["react", "react-dom", "@noorddev/raster"],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
 
   apps/www:
     dependencies:
-      '@noordvc/raster':
+      '@noorddev/raster':
         specifier: workspace:*
         version: link:../../packages/core
-      '@noordvc/raster-react':
+      '@noorddev/raster-react':
         specifier: workspace:*
         version: link:../../packages/react
       next:
@@ -47,7 +47,7 @@ importers:
 
   packages/cli:
     devDependencies:
-      '@noordvc/raster':
+      '@noorddev/raster':
         specifier: workspace:*
         version: link:../core
       '@types/node':
@@ -80,7 +80,7 @@ importers:
 
   packages/react:
     dependencies:
-      '@noordvc/raster':
+      '@noorddev/raster':
         specifier: workspace:^
         version: link:../core
     devDependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Renato created the npm org [`@noorddev`](https://www.npmjs.com/org/noorddev) (`@noordai` is 404). This retargets Raster’s publishable packages and every install/docs/CLI string onto that org.

Rebased onto current `main` after #8 (concentric radius), #9 (phone widths), #5 (small numerals), and #7 (copy control) landed.

**This rebase’s conflicts**
- `apps/www/app/docs/tokens/page.tsx` — kept concentric-radius imports/docs from #8 and the `@noorddev` names
- `apps/www/components/docs-nav/index.tsx` — kept `MobileToc` from #9 and the `@noorddev` import
- `apps/www/components/examples/concentric-radius/use.tsx` — retargeted the new Use import to `@noorddev/raster-react` (no text conflict; new on main)

Earlier rebase (Interfaces #3) already kept catalog crumbs + `three` transpile with `@noorddev` names.

**Renames**
- `@noordvc/raster` → `@noorddev/raster`
- `@noordvc/raster-react` → `@noorddev/raster-react`
- `@noordvc/raster-cli` → `@noorddev/raster-cli`

CI leftover needles still reject `@noordvc/` and `@noordai/`.

**Does not**
- npm publish
- Create the npm org
- Change GitHub repo names (`rennvaldes/raster` stays)
- Merge itself

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5489a087-87e2-4278-8097-830de4a51026?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5489a087-87e2-4278-8097-830de4a51026&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

