### PR TITLE
Add a copy control to command and code blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,39 @@ jobs:
           grep -q 'padding:8px 0 32px' packages/core/css/components/sidebar.css
           grep -q 'rs-sidebar-item:last-child' packages/core/css/components/sidebar.css
           grep -q 'padding-bottom:32px' packages/core/css/components/sidebar.css
+      - name: Code blocks copy
+        run: |
+          block=apps/www/components/code-block.tsx
+          css=apps/www/app/site.css
+          grep -q 'writeText' "$block"
+          grep -q 'aria-label' "$block"
+          grep -q 'Copied' "$block"
+          grep -q 'aria-live' "$block"
+          grep -q 'code-copy' "$css"
+          grep -q 'CopyControl' apps/www/app/page.tsx
+          grep -q 'CodeBlock' apps/www/app/docs/page.tsx
+          grep -q 'Coming from Raster 0.1' apps/www/app/docs/page.tsx
+          if grep -nE 'toast|Toaster|rs-toast' "$block"; then
+            echo "Copy must confirm on the control, not via toast"
+            exit 1
+          fi
+          if grep -nE 'tailwind|@radix|@radix-ui' "$block" "$css"; then
+            echo "Copy control must stay CSS-first"
+            exit 1
+          fi
+          if grep -Rn '<pre>' apps/www --include='*.tsx' | grep -v code-block.tsx; then
+            echo "Command and code blocks must go through CodeBlock"
+            exit 1
+          fi
+          node -e '
+            const { readFileSync } = require("node:fs");
+            const css = readFileSync("apps/www/app/site.css", "utf8");
+            const copy = css.slice(css.indexOf(".code-copy {"), css.indexOf(".code-copy:hover"));
+            if (!copy.includes("border-radius: 0") || !copy.includes("box-shadow: none")) {
+              console.error("Copy chrome must be flush: no radius, no shadow");
+              process.exit(1);
+            }
+          '
       - name: Every component has an isolated Use
         run: |
           test -f apps/www/components/examples/use.css

--- a/apps/www/app/specimen.css
+++ b/apps/www/app/specimen.css
@@ -69,6 +69,7 @@
   justify-content: flex-end;
 }
 .specimen-cell-command {
+  position: relative;
   grid-area: cmd;
   container-type: inline-size;
   justify-content: space-between;

--- a/apps/www/app/specimen.css
+++ b/apps/www/app/specimen.css
@@ -69,7 +69,6 @@
   justify-content: flex-end;
 }
 .specimen-cell-command {
-  position: relative;
   grid-area: cmd;
   container-type: inline-size;
   justify-content: space-between;

--- a/apps/www/components/code-block.tsx
+++ b/apps/www/components/code-block.tsx
@@ -6,8 +6,24 @@ import * as React from "react";
 function CopyMark() {
   return (
     <svg viewBox="0 0 16 16" width="16" height="16" fill="none" aria-hidden="true">
-      <rect x="5.5" y="2.5" width="8" height="8" stroke="currentColor" strokeWidth="1.5" />
-      <rect x="2.5" y="5.5" width="8" height="8" stroke="currentColor" strokeWidth="1.5" />
+      <rect
+        x="5.5"
+        y="2.5"
+        width="8"
+        height="8"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        vectorEffect="non-scaling-stroke"
+      />
+      <rect
+        x="2.5"
+        y="5.5"
+        width="8"
+        height="8"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        vectorEffect="non-scaling-stroke"
+      />
     </svg>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Command and code blocks on the Raster site had no copy affordance. Renato’s screenshot of the dark docs block (Getting started → Coming from Raster 0.1) is the example.

Rebased onto current `main` after #5 (small field numerals). Copy stays. The 12px field index from #5 stays.

- One click copies the command or snippet
- The button confirms on itself (icon swaps to the checkbox check + live region). No toast
- Native button, so keyboard still works; the snippet stays selectable
- Chrome only: Inter, monochrome, hairline flush, no radius, no shadow
- `@noordvc` scope is unchanged

Does not merge. Does not npm-publish. `ci.yml` still needs a browser click.

[Coming from Raster 0.1 with copy icon](https://cursor.com/agents/bc-6b699606-2e0e-48b1-a177-f5780622573a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_coming_from_0_1_copy_icon.png)
[Copied state after clicking the compat command](https://cursor.com/agents/bc-6b699606-2e0e-48b1-a177-f5780622573a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_coming_from_0_1_copied.png)
[Homepage command with copy control on the same row](https://cursor.com/agents/bc-6b699606-2e0e-48b1-a177-f5780622573a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_command_copy_icon.png)
[docs_copy_control.mp4](https://cursor.com/agents/bc-6b699606-2e0e-48b1-a177-f5780622573a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_copy_control.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b699606-2e0e-48b1-a177-f5780622573a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b699606-2e0e-48b1-a177-f5780622573a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

