### PR TITLE
Show the homepage navbar on scroll

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,14 @@ jobs:
           '
           grep -q 'specimen-page' "$page"
           grep -q 'isSpecimenPath' apps/www/components/crumb-bar.tsx
+          if grep -n 'if (isSpecimenPath(pathname)) return null' apps/www/components/crumb-bar.tsx; then
+            echo "Homepage must keep the site crumb bar"
+            exit 1
+          fi
+          if grep -n 'if (isSpecimenPath(pathname) || isFieldPath(pathname)) return null' apps/www/components/crumb-bar.tsx; then
+            echo "Homepage must keep the site crumb bar"
+            exit 1
+          fi
           test -f apps/www/app/specimen.css
           if grep -n specimen-page apps/www/app/site.css; then
             echo "Specimen styles drifted back into site chrome"

--- a/apps/www/app/specimen.ts
+++ b/apps/www/app/specimen.ts
@@ -22,12 +22,12 @@ function normalizePath(pathname: string) {
   return path === "" ? "/" : path;
 }
 
-/** Narrow exception: the flush poster has no crumb bar. */
+/** Homepage specimen. Uses the same scroll-in crumb bar as the rest of the site. */
 export function isSpecimenPath(pathname: string) {
   return normalizePath(pathname) === "/";
 }
 
-/** Flush field pages: homepage specimen and About. No crumb bar on the field. */
+/** Flush field pages. About stays without a crumb bar; homepage keeps site chrome. */
 export function isFieldPath(pathname: string) {
   const path = normalizePath(pathname);
   return path === "/" || path === "/about";

--- a/apps/www/components/crumb-bar.tsx
+++ b/apps/www/components/crumb-bar.tsx
@@ -15,7 +15,9 @@ interface Crumb {
 function trailFor(pathname: string): Crumb[] {
   const parts = pathname.split("/").filter(Boolean);
   const trail: Crumb[] = [];
-  if (parts[0] === "docs") {
+  if (parts.length === 0) {
+    trail.push({ label: "Home" });
+  } else if (parts[0] === "docs") {
     trail.push({ label: "Docs", href: "/docs" });
     if (parts[1] === "tokens") trail.push({ label: "Tokens" });
     else trail.push({ label: "Getting started" });
@@ -55,8 +57,8 @@ export function CrumbBar() {
 
   const trail = trailFor(pathname);
 
-  /* Exception: specimen and About are flush fields. No crumb bar on the field. */
-  if (isSpecimenPath(pathname) || isFieldPath(pathname)) return null;
+  /* About stays a flush field. Homepage keeps the same scroll-in chrome. */
+  if (isFieldPath(pathname) && !isSpecimenPath(pathname)) return null;
 
   return (
     <nav className={`rs-crumb-bar${scrolled ? " rs-crumb-bar-scrolled" : ""}`} aria-label="Breadcrumbs">

--- a/apps/www/components/docs-nav/FEATURE.md
+++ b/apps/www/components/docs-nav/FEATURE.md
@@ -2,7 +2,7 @@
 
 What it is, how to get there, what done looks like.
 
-Writers: catalog groups are `packages/core/src/schema.ts` (`rasterCategories`). Face, law, and command are `apps/www/app/specimen.ts`. Numbered laws are `apps/www/app/specimen-laws.ts`. The crumb bar is off on `/` and `/about` (`isFieldPath`) so the field stays flush.
+Writers: catalog groups are `packages/core/src/schema.ts` (`rasterCategories`). Face, law, and command are `apps/www/app/specimen.ts`. Numbered laws are `apps/www/app/specimen-laws.ts`. Homepage `/` uses the same scroll-in crumb bar as docs and components. The crumb bar stays off on `/about` so that field stays flush.
 
 | Surface | Route | Click path | Done |
 | --- | --- | --- | --- |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Draft. Do not merge. Do not publish to npm.

The homepage specimen skipped the site crumb bar, so `/` never got the scroll-in chrome that docs, components, and interfaces already use.

This keeps that same bar on the homepage: transparent at rest, paper and a Raster hairline after scroll, with `Raster / Home` in sentence case. About stays a flush field. Homepage copy and slogans are untouched.

## Preview (READY)

- Site: https://raster-git-cursor-homepage-navbar-on-68094e-renn-1738s-projects.vercel.app/
- SSO share: https://raster-git-cursor-homepage-navbar-on-68094e-renn-1738s-projects.vercel.app/?_vercel_share=cRD5nudVv6Kj7W3866U4UZrrA0P5bVg0

## Verify

Local, desktop (~1280):

- `/` at rest: `nav.rs-crumb-bar` present, no `rs-crumb-bar-scrolled`. Corner chrome (logo, Docs / Components / Interfaces / About / GitHub, theme) stays. Copy unchanged: Raster, “A design system on a modular grid.”, `npx @noorddev/raster-cli init`.
- `/` after scroll: `rs-crumb-bar-scrolled` — paper, hairline, `Raster / Home`.
- `/docs` and `/components`: same transparent → paper + hairline pattern.
- `/about`: still no crumb bar.

CI is green. No npm publish.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ce2e6d8-f93a-44fc-93b6-45c9362c9765?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ce2e6d8-f93a-44fc-93b6-45c9362c9765&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

