### PR TITLE
Recut mobile chrome: About navbar on scroll, one-line crumbs, one toggle mark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,13 +96,13 @@ jobs:
           assert (w, h) == (1200, 630), f"og.png must be 1200×630, got {w}×{h}"
           '
           grep -q 'specimen-page' "$page"
-          grep -q 'isSpecimenPath' apps/www/components/crumb-bar.tsx
-          if grep -n 'if (isSpecimenPath(pathname)) return null' apps/www/components/crumb-bar.tsx; then
-            echo "Homepage must keep the site crumb bar"
+          grep -q 'rs-crumb-bar' apps/www/components/crumb-bar.tsx
+          if grep -n 'return null' apps/www/components/crumb-bar.tsx; then
+            echo "Crumb bar must run on every route, including Home and About"
             exit 1
           fi
-          if grep -n 'if (isSpecimenPath(pathname) || isFieldPath(pathname)) return null' apps/www/components/crumb-bar.tsx; then
-            echo "Homepage must keep the site crumb bar"
+          if grep -n 'isFieldPath(pathname)' apps/www/components/crumb-bar.tsx; then
+            echo "About must keep the same navbar-on-scroll as home"
             exit 1
           fi
           test -f apps/www/app/specimen.css

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,9 +350,8 @@ jobs:
             exit 1
           fi
           chrome=apps/www/components/site-chrome.tsx
-          grep -q 'name="sun"' "$chrome"
-          grep -q 'name="moon"' "$chrome"
-          grep -q '@noorddev/raster-react' "$chrome"
+          grep -q 'SettingsMark' "$chrome"
+          grep -q 'M2 4.5h5M11 4.5h3M2 11.5h3M9 11.5h5' "$chrome"
           grep -q 'name="calendar"' packages/react/src/components/date-picker.tsx
           grep -q 'r(3, 4.5, 10, 9)' "$marks"
           if grep -nE 'M13.5 9.5A5.5|r="3.25"' "$chrome" packages/react/src/components/theme-toggle.tsx; then

--- a/apps/www/app/site.css
+++ b/apps/www/app/site.css
@@ -143,12 +143,14 @@ html, body { margin: 0; padding: 0; }
     height: calc(56px + env(safe-area-inset-top, 0px));
     padding-top: env(safe-area-inset-top, 0px);
     font-size: 15px;
+    line-height: 1;
     overflow: hidden;
     align-items: flex-start;
   }
   .rs-crumb-bar-inner {
     display: flex;
     flex-wrap: nowrap;
+    flex-direction: row;
     align-items: center;
     min-width: 0;
     min-height: 44px;
@@ -157,6 +159,13 @@ html, body { margin: 0; padding: 0; }
     overflow: hidden;
     padding: 0 calc(108px + env(safe-area-inset-right, 0px)) 0 calc(60px + env(safe-area-inset-left, 0px));
   }
+  /* Inter’s cap-height sits ~3px above the 44px icon midline (logo / toggle / menu). */
+  .rs-crumb-root,
+  .rs-crumb-bar .rs-crumbs-link,
+  .rs-crumb-bar .rs-crumbs-sep,
+  .rs-crumb-bar .rs-crumbs-here {
+    transform: translateY(3px);
+  }
   .rs-crumb-root {
     display: inline-flex; align-items: center;
     flex-shrink: 0; height: 44px; min-height: 0;
@@ -164,6 +173,7 @@ html, body { margin: 0; padding: 0; }
   .rs-crumb-bar .rs-crumbs {
     display: flex;
     flex-wrap: nowrap;
+    flex-direction: row;
     align-items: center;
     min-width: 0;
     flex: 1 1 auto;
@@ -182,7 +192,7 @@ html, body { margin: 0; padding: 0; }
     min-height: 0;
     height: 44px;
     line-height: 44px;
-    flex: 1 1 auto;
+    flex: 1 1 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -228,6 +238,11 @@ html, body { margin: 0; padding: 0; }
   .theme-toggle { right: calc(56px + env(safe-area-inset-right, 0px)); }
   .nav-toggle { right: calc(8px + env(safe-area-inset-right, 0px)); }
   .nav-panel-link, .nav-panel-theme { padding-left: 25px; padding-right: 25px; }
+  .rs-crumb-bar-inner {
+    flex-wrap: nowrap;
+    padding: 0 calc(108px + env(safe-area-inset-right, 0px)) 0 calc(60px + env(safe-area-inset-left, 0px));
+  }
+  .rs-crumb-bar .rs-crumbs { flex-wrap: nowrap; }
 }
 
 /* ── Layout: one module in, width snapped to whole modules ── */

--- a/apps/www/app/site.css
+++ b/apps/www/app/site.css
@@ -159,16 +159,10 @@ html, body { margin: 0; padding: 0; }
     overflow: hidden;
     padding: 0 calc(108px + env(safe-area-inset-right, 0px)) 0 calc(60px + env(safe-area-inset-left, 0px));
   }
-  /* Inter’s cap-height sits ~3px above the 44px icon midline (logo / toggle / menu). */
-  .rs-crumb-root,
-  .rs-crumb-bar .rs-crumbs-link,
-  .rs-crumb-bar .rs-crumbs-sep,
-  .rs-crumb-bar .rs-crumbs-here {
-    transform: translateY(3px);
-  }
   .rs-crumb-root {
     display: inline-flex; align-items: center;
     flex-shrink: 0; height: 44px; min-height: 0;
+    line-height: 1;
   }
   .rs-crumb-bar .rs-crumbs {
     display: flex;

--- a/apps/www/app/site.css
+++ b/apps/www/app/site.css
@@ -18,7 +18,8 @@ html, body { margin: 0; padding: 0; }
 /* ── Fixed corner chrome ── */
 .logo-wrap {
   position: fixed; top: 24px; left: 20px; z-index: 200;
-  display: flex; align-items: center; gap: 12px;
+  display: flex; align-items: center; justify-content: center; gap: 12px;
+  height: 24px;
 }
 /* The Raster glyph, bare: ink on the page, no tile (house spec: 20px). */
 .site-logo {
@@ -107,9 +108,16 @@ html, body { margin: 0; padding: 0; }
   .logo-wrap {
     top: calc(8px + env(safe-area-inset-top, 0px));
     left: calc(8px + env(safe-area-inset-left, 0px));
+    height: 44px;
+    min-height: 44px;
   }
   .site-logo {
     width: 44px; height: 44px; min-width: 44px; min-height: 44px;
+  }
+  /* Rotated mark reads high vs 15px Raster/crumbs; drop it onto that middle. */
+  .site-logo-mark {
+    position: relative;
+    top: 1px;
   }
   .corner-nav { display: none; }
   .theme-toggle {

--- a/apps/www/app/site.css
+++ b/apps/www/app/site.css
@@ -46,7 +46,8 @@ html, body { margin: 0; padding: 0; }
 
 .theme-toggle {
   position: fixed; top: 24px; right: 20px; z-index: 200;
-  width: 24px; height: 24px; padding: 4px; overflow: hidden;
+  width: 24px; height: 24px; padding: 0; overflow: hidden;
+  display: flex; align-items: center; justify-content: center;
   background: none; border: none; border-radius: 0;
   color: var(--text-secondary); cursor: pointer; outline: none;
   filter: drop-shadow(0 0 12px var(--bg)) drop-shadow(0 0 20px var(--bg));
@@ -54,20 +55,9 @@ html, body { margin: 0; padding: 0; }
 }
 .theme-toggle:hover { color: var(--text); }
 .theme-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-/* The sun/moon pair slides on a track (house idiom). */
-.toggle-track {
-  display: flex; flex-direction: column; align-items: center; gap: 8px;
-  transition: transform var(--duration) var(--ease);
+.theme-toggle svg {
+  display: block; width: 16px; height: 16px; flex-shrink: 0;
 }
-.icon-sun, .icon-moon {
-  width: 16px; height: 16px; flex-shrink: 0;
-  transition: opacity var(--duration) var(--ease);
-}
-.toggle-track .icon-moon { opacity: 1; }
-.toggle-track .icon-sun { opacity: .35; }
-.toggle-track.is-dark { transform: translateY(-24px); }
-.toggle-track.is-dark .icon-sun { opacity: 1; }
-.toggle-track.is-dark .icon-moon { opacity: .35; }
 
 /* Mobile: burger + panel replace the corner links. Theme stays in chrome. */
 .nav-toggle {
@@ -123,11 +113,11 @@ html, body { margin: 0; padding: 0; }
   }
   .corner-nav { display: none; }
   .theme-toggle {
-    display: flex; align-items: flex-start; justify-content: center;
+    display: flex; align-items: center; justify-content: center;
     top: calc(8px + env(safe-area-inset-top, 0px));
     right: calc(56px + env(safe-area-inset-right, 0px));
     width: 44px; height: 44px; min-width: 44px; min-height: 44px;
-    padding: 14px;
+    padding: 0;
     overflow: hidden;
     border-radius: 0;
   }
@@ -153,15 +143,49 @@ html, body { margin: 0; padding: 0; }
     height: calc(56px + env(safe-area-inset-top, 0px));
     padding-top: env(safe-area-inset-top, 0px);
     font-size: 15px;
+    overflow: hidden;
+    align-items: flex-start;
   }
   .rs-crumb-bar-inner {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    min-width: 0;
     min-height: 44px;
+    height: 44px;
+    margin-top: 8px;
+    overflow: hidden;
     padding: 0 calc(108px + env(safe-area-inset-right, 0px)) 0 calc(60px + env(safe-area-inset-left, 0px));
   }
-  .rs-crumb-root,
+  .rs-crumb-root {
+    display: inline-flex; align-items: center;
+    flex-shrink: 0; height: 44px; min-height: 0;
+  }
+  .rs-crumb-bar .rs-crumbs {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    min-width: 0;
+    flex: 1 1 auto;
+    overflow: hidden;
+    white-space: nowrap;
+  }
   .rs-crumbs-link,
   .rs-crumb-bar a {
-    display: inline-flex; align-items: center; min-height: 44px;
+    display: inline-flex; align-items: center;
+    flex-shrink: 0; height: 44px; min-height: 0;
+  }
+  .rs-crumb-bar .rs-crumbs-sep { flex-shrink: 0; }
+  .rs-crumb-bar .rs-crumbs-here {
+    display: block;
+    min-width: 0;
+    min-height: 0;
+    height: 44px;
+    line-height: 44px;
+    flex: 1 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .cover { padding-bottom: 40px; }
   .site-content { padding-bottom: calc(72px + env(safe-area-inset-bottom, 0px)); }
@@ -387,9 +411,6 @@ html, body { margin: 0; padding: 0; }
 .site-footer a { color: inherit; }
 
 @media (prefers-reduced-motion: reduce) {
-  .toggle-track,
-  .icon-sun,
-  .icon-moon,
   .nav-panel,
   .nav-toggle-icon span { transition: none; }
 }

--- a/apps/www/app/specimen.ts
+++ b/apps/www/app/specimen.ts
@@ -27,7 +27,7 @@ export function isSpecimenPath(pathname: string) {
   return normalizePath(pathname) === "/";
 }
 
-/** Flush field pages. About stays without a crumb bar; homepage keeps site chrome. */
+/** Flush field pages. Home and About both keep the scroll-in crumb bar. */
 export function isFieldPath(pathname: string) {
   const path = normalizePath(pathname);
   return path === "/" || path === "/about";

--- a/apps/www/components/crumb-bar.tsx
+++ b/apps/www/components/crumb-bar.tsx
@@ -5,7 +5,6 @@ import { usePathname } from "next/navigation";
 import * as React from "react";
 import { rasterComponents } from "@noorddev/raster";
 import { interfaceBySlug } from "@/app/interfaces/catalog";
-import { isFieldPath, isSpecimenPath } from "@/app/specimen";
 
 interface Crumb {
   label: string;
@@ -40,9 +39,9 @@ function trailFor(pathname: string): Crumb[] {
 }
 
 /**
- * The fixed top bar, on every page. Transparent at rest; once the
- * cover scrolls away it gains the paper background and its bottom
- * hairline, and the breadcrumbs appear.
+ * The fixed top bar, on every page including Home and About.
+ * Transparent at rest; once the cover scrolls away it gains the paper
+ * background and its bottom hairline, and the breadcrumbs appear.
  */
 export function CrumbBar() {
   const pathname = usePathname();
@@ -56,9 +55,6 @@ export function CrumbBar() {
   }, []);
 
   const trail = trailFor(pathname);
-
-  /* About stays a flush field. Homepage keeps the same scroll-in chrome. */
-  if (isFieldPath(pathname) && !isSpecimenPath(pathname)) return null;
 
   return (
     <nav className={`rs-crumb-bar${scrolled ? " rs-crumb-bar-scrolled" : ""}`} aria-label="Breadcrumbs">

--- a/apps/www/components/docs-nav/FEATURE.md
+++ b/apps/www/components/docs-nav/FEATURE.md
@@ -2,7 +2,7 @@
 
 What it is, how to get there, what done looks like.
 
-Writers: catalog groups are `packages/core/src/schema.ts` (`rasterCategories`). Face, law, and command are `apps/www/app/specimen.ts`. Numbered laws are `apps/www/app/specimen-laws.ts`. Homepage `/` uses the same scroll-in crumb bar as docs and components. The crumb bar stays off on `/about` so that field stays flush.
+Writers: catalog groups are `packages/core/src/schema.ts` (`rasterCategories`). Face, law, and command are `apps/www/app/specimen.ts`. Numbered laws are `apps/www/app/specimen-laws.ts`. Homepage `/` and About `/about` use the same scroll-in crumb bar as docs and components: transparent at rest, paper and a 1px divider after scroll.
 
 | Surface | Route | Click path | Done |
 | --- | --- | --- | --- |
@@ -12,6 +12,6 @@ Writers: catalog groups are `packages/core/src/schema.ts` (`rasterCategories`). 
 | Getting started | `/docs` | Corner → Docs | Short rail: Getting started, Tokens. Command is the one in `app/specimen.ts` (`npx @noorddev/raster-cli init`). Command and code blocks carry a quiet copy control. Under 900 the rail hides; a stacked 44pt contents picker takes its place. |
 | Tokens | `/docs/tokens` | Docs → Tokens | Same short rail. Same phone picker. |
 | Phone | ≤430 | Burger, theme, contents | 44pt hits on chrome, TOC, catalog tiles, copy. Kit controls recut at ≤640 (44pt, 16px, full-width). Safe-area insets. One column. Desktop rail and 20px mark stay. |
-| About | `/about` | Corner → About | Flush field. Site 204 verticals run the full page, same spine as home (20 / 204 / 224 / 408) — not a local hero tile. A modernist homage — Swiss Style and Dutch modernism. Josef Müller-Brockmann and Wim Crouwel as type-in-cells; Max Bill, Karl Gerstner, Emil Ruder, Armin Hofmann, Piet Zwart, Paul Schuitema, Otto Treumann, Total Design, Swiss Style. Illustrated programme: 204, hairlines, flush / 0, grotesque. Credits (Inter, Noord, Renato, packages) are a 12px colophon, not a masthead. Isolated files under `app/about`. |
+| About | `/about` | Corner → About | Flush field. Site 204 verticals run the full page, same spine as home (20 / 204 / 224 / 408) — not a local hero tile. Same navbar-on-scroll as home. A modernist homage — Swiss Style and Dutch modernism. Josef Müller-Brockmann and Wim Crouwel as type-in-cells; Max Bill, Karl Gerstner, Emil Ruder, Armin Hofmann, Piet Zwart, Paul Schuitema, Otto Treumann, Total Design, Swiss Style. Illustrated programme: 204, hairlines, flush / 0, grotesque. Credits (Inter, Noord, Renato, packages) are a 12px colophon, not a masthead. Isolated files under `app/about`. |
 
 The components rail is groups → items. It is not Getting started / Foundations / Components.

--- a/apps/www/components/site-chrome.tsx
+++ b/apps/www/components/site-chrome.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Icon } from "@noorddev/raster-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import * as React from "react";
@@ -18,10 +17,6 @@ function RasterMark() {
 }
 
 function useTheme() {
-  const [dark, setDark] = React.useState<boolean | null>(null);
-  React.useEffect(() => {
-    setDark(document.documentElement.dataset.theme === "dark");
-  }, []);
   const toggle = () => {
     const next = !(document.documentElement.dataset.theme === "dark");
     if (next) document.documentElement.dataset.theme = "dark";
@@ -31,13 +26,19 @@ function useTheme() {
     } catch {
       /* private mode */
     }
-    setDark(next);
   };
-  return { dark, toggle };
+  return { toggle };
 }
 
-function ThemeIcon({ dark }: { dark: boolean | null }) {
-  return dark ? <Icon name="sun" size={16} /> : <Icon name="moon" size={16} />;
+/* Same sliders mark as the top-right control on renatovaldes.com. One glyph, no track. */
+function SettingsMark() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round">
+      <path d="M2 4.5h5M11 4.5h3M2 11.5h3M9 11.5h5" />
+      <circle cx="9" cy="4.5" r="1.9" />
+      <circle cx="7" cy="11.5" r="1.9" />
+    </svg>
+  );
 }
 
 const links = [
@@ -50,7 +51,7 @@ const links = [
 
 export function SiteChrome() {
   const pathname = usePathname();
-  const { dark, toggle } = useTheme();
+  const { toggle } = useTheme();
   const [open, setOpen] = React.useState(false);
 
   React.useEffect(() => setOpen(false), [pathname]);
@@ -83,7 +84,7 @@ export function SiteChrome() {
       </nav>
 
       <button type="button" className="theme-toggle" onClick={toggle} aria-label="Toggle color scheme">
-        <ThemeIcon dark={dark} />
+        <SettingsMark />
       </button>
 
       <button
@@ -113,7 +114,7 @@ export function SiteChrome() {
         </div>
         <button className="nav-panel-theme" type="button" onClick={toggle}>
           <span>Appearance</span>
-          <ThemeIcon dark={dark} />
+          <SettingsMark />
         </button>
       </nav>
     </>

--- a/apps/www/components/site-chrome.tsx
+++ b/apps/www/components/site-chrome.tsx
@@ -33,7 +33,7 @@ function useTheme() {
 /* Same sliders mark as the top-right control on renatovaldes.com. One glyph, no track. */
 function SettingsMark() {
   return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round">
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true" stroke="currentColor" strokeWidth="1" strokeLinecap="butt">
       <path d="M2 4.5h5M11 4.5h3M2 11.5h3M9 11.5h5" />
       <circle cx="9" cy="4.5" r="1.9" />
       <circle cx="7" cy="11.5" r="1.9" />

--- a/apps/www/components/site-chrome.tsx
+++ b/apps/www/components/site-chrome.tsx
@@ -83,10 +83,7 @@ export function SiteChrome() {
       </nav>
 
       <button type="button" className="theme-toggle" onClick={toggle} aria-label="Toggle color scheme">
-        <span className={`toggle-track${dark ? " is-dark" : ""}`}>
-          <Icon name="moon" size={16} className="icon-moon" />
-          <Icon name="sun" size={16} className="icon-sun" />
-        </span>
+        <ThemeIcon dark={dark} />
       </button>
 
       <button

--- a/apps/www/scripts/check-mobile.mjs
+++ b/apps/www/scripts/check-mobile.mjs
@@ -145,6 +145,12 @@ if (!tokensCss.includes("--hit:44px") && !tokensCss.includes("--hit: 44px")) {
 if (!phoneCss.includes("@media(max-width:640px)") && !phoneCss.includes("@media (max-width: 640px)")) {
   fail("phone.css must recut interactive controls at 640");
 }
+if (!phoneCss.includes(".rs-cal-day") || !/\.rs-cal-day\{[^}]*width:36px;\s*height:36px/.test(phoneCss)) {
+  fail("Phone calendar selected day must stay a 36×36 square, not a 44-tall cell");
+}
+if (/\.rs-cal-day\{[^}]*height:var\(--hit\)/.test(phoneCss) || /\.rs-cal-grid\{[^}]*minmax\(0,1fr\)/.test(phoneCss)) {
+  fail("Do not stretch calendar days to fluid × 44 on phone");
+}
 for (const sel of [".rs-btn-primary", ".rs-input", ".rs-tab", ".rs-switch"]) {
   if (!phoneCss.includes(sel)) fail(`phone.css must recut ${sel}`);
 }

--- a/apps/www/scripts/check-mobile.mjs
+++ b/apps/www/scripts/check-mobile.mjs
@@ -48,6 +48,12 @@ if (phone.includes(".theme-toggle { display: none") || /corner-nav,\s*\.theme-to
 if (!phone.includes("overflow: hidden") || !phone.includes("flex-wrap: nowrap")) {
   fail("Phone crumb bar must clip to one line; crumbs must not wrap out of the bar");
 }
+if (!phone.includes("translateY(3px)") || !phone.includes(".rs-crumbs-here")) {
+  fail("Phone crumb type must sit on the same optical middle as the 44px icons");
+}
+if (!phone.includes("flex: 1 1 0")) {
+  fail("Phone crumb leaf must shrink and ellipsize so the trail stays one line at 375");
+}
 if (chrome.includes("toggle-track") || chrome.includes("icon-moon") || chrome.includes("icon-sun")) {
   fail("Site chrome toggle must show one icon for the current scheme, not a sliding pair");
 }

--- a/apps/www/scripts/check-mobile.mjs
+++ b/apps/www/scripts/check-mobile.mjs
@@ -48,8 +48,8 @@ if (phone.includes(".theme-toggle { display: none") || /corner-nav,\s*\.theme-to
 if (!phone.includes("overflow: hidden") || !phone.includes("flex-wrap: nowrap")) {
   fail("Phone crumb bar must clip to one line; crumbs must not wrap out of the bar");
 }
-if (!phone.includes("translateY(3px)") || !phone.includes(".rs-crumbs-here")) {
-  fail("Phone crumb type must sit on the same optical middle as the 44px icons");
+if (phone.includes("translateY(3px)")) {
+  fail("Do not translate crumb type 3px down; that sits ink below the icon midline");
 }
 if (!phone.includes("flex: 1 1 0")) {
   fail("Phone crumb leaf must shrink and ellipsize so the trail stays one line at 375");

--- a/apps/www/scripts/check-mobile.mjs
+++ b/apps/www/scripts/check-mobile.mjs
@@ -45,6 +45,23 @@ if (!phone.includes(".theme-toggle") || !phone.includes("display: flex")) {
 if (phone.includes(".theme-toggle { display: none") || /corner-nav,\s*\.theme-toggle/.test(phone)) {
   fail("Do not hide the theme toggle on phone");
 }
+if (!phone.includes("overflow: hidden") || !phone.includes("flex-wrap: nowrap")) {
+  fail("Phone crumb bar must clip to one line; crumbs must not wrap out of the bar");
+}
+if (chrome.includes("toggle-track") || chrome.includes("icon-moon") || chrome.includes("icon-sun")) {
+  fail("Site chrome toggle must show one icon for the current scheme, not a sliding pair");
+}
+if (!chrome.includes("<ThemeIcon dark={dark} />")) {
+  fail("Site chrome toggle must render one mark matching the current scheme");
+}
+
+const crumbs = readFileSync(join(root, "apps/www/components/crumb-bar.tsx"), "utf8");
+if (crumbs.includes("return null") || crumbs.includes("isFieldPath")) {
+  fail("About must use the same scroll-in crumb bar as home");
+}
+if (!crumbs.includes('parts[0] === "about"')) {
+  fail("Crumb bar must trail About");
+}
 
 if (!nav.includes("MobileToc") || !nav.includes("toc-mobile-item")) {
   fail("DocsNav must render a stacked phone TOC");

--- a/apps/www/scripts/check-mobile.mjs
+++ b/apps/www/scripts/check-mobile.mjs
@@ -57,11 +57,11 @@ if (!phone.includes(".site-logo-mark") || !phone.includes("top: 1px")) {
 if (!phone.includes("flex: 1 1 0")) {
   fail("Phone crumb leaf must shrink and ellipsize so the trail stays one line at 375");
 }
-if (chrome.includes("toggle-track") || chrome.includes("icon-moon") || chrome.includes("icon-sun")) {
-  fail("Site chrome toggle must show one icon for the current scheme, not a sliding pair");
+if (chrome.includes("toggle-track") || chrome.includes("icon-moon") || chrome.includes("icon-sun") || chrome.includes("SunIcon") || chrome.includes("MoonIcon")) {
+  fail("Site chrome toggle must show one mark, not a sun/moon pair");
 }
-if (!chrome.includes("<ThemeIcon dark={dark} />")) {
-  fail("Site chrome toggle must render one mark matching the current scheme");
+if (!chrome.includes('d="M2 4.5h5M11 4.5h3M2 11.5h3M9 11.5h5"') || !chrome.includes("<SettingsMark />")) {
+  fail("Site chrome toggle must use the sliders mark from renatovaldes.com");
 }
 
 const crumbs = readFileSync(join(root, "apps/www/components/crumb-bar.tsx"), "utf8");

--- a/apps/www/scripts/check-mobile.mjs
+++ b/apps/www/scripts/check-mobile.mjs
@@ -51,6 +51,9 @@ if (!phone.includes("overflow: hidden") || !phone.includes("flex-wrap: nowrap"))
 if (phone.includes("translateY(3px)")) {
   fail("Do not translate crumb type 3px down; that sits ink below the icon midline");
 }
+if (!phone.includes(".site-logo-mark") || !phone.includes("top: 1px")) {
+  fail("Phone logo mark must sit on the same optical middle as Raster / crumbs");
+}
 if (!phone.includes("flex: 1 1 0")) {
   fail("Phone crumb leaf must shrink and ellipsize so the trail stays one line at 375");
 }

--- a/packages/core/css/phone.css
+++ b/packages/core/css/phone.css
@@ -240,18 +240,19 @@
     min-height:var(--hit);
   }
 
-  /* Calendar: full width, 44×44 days */
-  .rs-cal{width:100%}
+  /* Calendar: 36×36 day squares (PR 17). Nav chevrons stay 44pt. */
+  .rs-cal{width:252px}
+  .rs-cal-head{min-height:var(--hit);align-items:center}
   .rs-cal-title{font-size:var(--control-fs)}
-  .rs-cal-nav{gap:8px}
-  .rs-cal-grid{grid-template-columns:repeat(7,minmax(0,1fr));width:100%}
-  .rs-cal-dow{font-size:13px;padding:8px 0}
+  .rs-cal-nav{gap:8px;flex-shrink:0}
+  .rs-cal-grid{grid-template-columns:repeat(7,36px);width:252px}
+  .rs-cal-dow{font-size:13px;padding:4px 0}
   .rs-cal-day{
-    width:100%;
-    height:var(--hit);
-    min-height:var(--hit);
-    font-size:var(--control-fs);
-    border-radius:0;
+    width:36px;
+    height:36px;
+    min-width:36px;
+    min-height:36px;
+    box-sizing:border-box;
   }
 
   /* Sidebar: 44pt rows, 16px. Desktop padding:8px 0 32px stays in sidebar.css. */

--- a/packages/core/css/raster-compat.css
+++ b/packages/core/css/raster-compat.css
@@ -598,18 +598,19 @@ table tr.rs-total-row td{font-weight:500;color:var(--text);border-top:2px solid 
     min-height:var(--hit);
   }
 
-  /* Calendar: full width, 44×44 days */
-  .rs-cal{width:100%}
+  /* Calendar: 36×36 day squares (PR 17). Nav chevrons stay 44pt. */
+  .rs-cal{width:252px}
+  .rs-cal-head{min-height:var(--hit);align-items:center}
   .rs-cal-title{font-size:var(--control-fs)}
-  .rs-cal-nav{gap:8px}
-  .rs-cal-grid{grid-template-columns:repeat(7,minmax(0,1fr));width:100%}
-  .rs-cal-dow{font-size:13px;padding:8px 0}
+  .rs-cal-nav{gap:8px;flex-shrink:0}
+  .rs-cal-grid{grid-template-columns:repeat(7,36px);width:252px}
+  .rs-cal-dow{font-size:13px;padding:4px 0}
   .rs-cal-day{
-    width:100%;
-    height:var(--hit);
-    min-height:var(--hit);
-    font-size:var(--control-fs);
-    border-radius:0;
+    width:36px;
+    height:36px;
+    min-width:36px;
+    min-height:36px;
+    box-sizing:border-box;
   }
 
   /* Sidebar: 44pt rows, 16px. Desktop padding:8px 0 32px stays in sidebar.css. */

--- a/packages/core/css/raster.css
+++ b/packages/core/css/raster.css
@@ -1137,18 +1137,19 @@ dialog.rs-drawer::backdrop{background:rgba(0,0,0,0.25)}
     min-height:var(--hit);
   }
 
-  /* Calendar: full width, 44×44 days */
-  .rs-cal{width:100%}
+  /* Calendar: 36×36 day squares (PR 17). Nav chevrons stay 44pt. */
+  .rs-cal{width:252px}
+  .rs-cal-head{min-height:var(--hit);align-items:center}
   .rs-cal-title{font-size:var(--control-fs)}
-  .rs-cal-nav{gap:8px}
-  .rs-cal-grid{grid-template-columns:repeat(7,minmax(0,1fr));width:100%}
-  .rs-cal-dow{font-size:13px;padding:8px 0}
+  .rs-cal-nav{gap:8px;flex-shrink:0}
+  .rs-cal-grid{grid-template-columns:repeat(7,36px);width:252px}
+  .rs-cal-dow{font-size:13px;padding:4px 0}
   .rs-cal-day{
-    width:100%;
-    height:var(--hit);
-    min-height:var(--hit);
-    font-size:var(--control-fs);
-    border-radius:0;
+    width:36px;
+    height:36px;
+    min-width:36px;
+    min-height:36px;
+    box-sizing:border-box;
   }
 
   /* Sidebar: 44pt rows, 16px. Desktop padding:8px 0 32px stays in sidebar.css. */

--- a/packages/core/test/css.test.ts
+++ b/packages/core/test/css.test.ts
@@ -75,11 +75,16 @@ describe("generated raster.css", () => {
 
   it("keeps calendar days square and drops the month chevrons 1px", () => {
     const cal = readFileSync(join(pkgDir, "css/components/calendar.css"), "utf8");
+    const phone = readFileSync(join(pkgDir, "css/phone.css"), "utf8");
     expect(cal).toMatch(/\.rs-cal-day\{[^}]*width:36px;height:36px/);
     expect(cal).not.toMatch(/height:32px/);
     expect(cal).toMatch(/\.rs-cal-nav \.rs-page\{transform:translateY\(1px\)\}/);
     expect(cal).toMatch(/\.rs-cal-title\{[^}]*line-height:26px/);
     expect(rasterCss).toMatch(/\.rs-cal-day\{[^}]*width:36px;height:36px/);
+    expect(phone).toMatch(/\.rs-cal-day\{[^}]*width:36px;\s*height:36px/);
+    expect(phone).toMatch(/\.rs-cal-grid\{[^}]*repeat\(7,36px\)/);
+    expect(phone).not.toMatch(/\.rs-cal-day\{[^}]*height:var\(--hit\)/);
+    expect(phone).not.toMatch(/\.rs-cal-grid\{[^}]*minmax\(0,1fr\)/);
   });
 
   it("joins button groups on one hairline and the button radius", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Draft. Do not merge. Do not publish to npm. Does not recut homepage copy, Interfaces, icons (PR 18), grid (PR 20), or concentric radius (PR 21). Does not recut the catalog ThemeToggle specimen (sibling draft from main). Does not invent a range state.

## What this PR owns

1. **`/about` navbar on scroll.** Same paper + hairline as home.
2. **Long crumbs stay in the bar** at 375 and 390; the leaf ellipsizes.
3. **Theme toggle mark.** Same sliders as the top-right control on [renatovaldes.com](https://renatovaldes.com). One 16px glyph (`stroke` 1.4, two lines with knobs). Not a sun/moon track. Tap still flips the scheme. Catalog specimen untouched.
4. **One optical middle.** Logo, Raster/crumbs, toggle, and menu.
5. **Calendar selected day 36×36 on phone.** Chevrons 44×44. Desktop 36×36 unchanged.

Leave draft. Do not merge.

## Preview

Head `bf97666`. https://raster-git-cursor-mobile-chrome-recut-23fe-renn-1738s-projects.vercel.app/

SSO: https://raster-git-cursor-mobile-chrome-recut-23fe-renn-1738s-projects.vercel.app/?_vercel_share=zRZjshyGyVMmajaW7tEM10XC1q3mX9oD

## Verify

Live top-right mark on renatovaldes.com, then Raster chrome (one SVG, tap light → dark, no track).

[Live sliders mark on renatovaldes.com](https://cursor.com/agents/bc-97657eaa-6db4-4b1d-b580-154ca1e723fe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Frenatovaldes_toggle_live.png)
[Raster phone navbar with sliders theme toggle](https://cursor.com/agents/bc-97657eaa-6db4-4b1d-b580-154ca1e723fe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftoggle_sliders_390.png)
[Raster sliders mark in dark after tap](https://cursor.com/agents/bc-97657eaa-6db4-4b1d-b580-154ca1e723fe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftoggle_sliders_dark.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97657eaa-6db4-4b1d-b580-154ca1e723fe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97657eaa-6db4-4b1d-b580-154ca1e723fe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

