### PR TITLE
Keep Press job state labels from wrapping

### DIFF
--- a/apps/www/app/interfaces/press/scene.css
+++ b/apps/www/app/interfaces/press/scene.css
@@ -165,6 +165,11 @@
 }
 .sc-dash-job[aria-current="true"] { font-weight: 600; }
 .sc-dash-job small { color: var(--text-secondary); font-weight: 400; }
+.sc-dash-job .if-ico-row { min-width: 0; }
+.sc-dash-job > span:last-child {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
 .sc-dash-detail {
   margin: 0;
   padding: 12px 20px 16px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Draft. Do not merge. Do not publish to npm.

Follow-up to #25 (already on main). Five lines on Press so job state labels (`On press`, `Proof`, `Invoice`, `Brief`) stay on one line when the jobs column is tight beside the sheet. Leading Raster marks on jobs are unchanged.

Leave draft. Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a61a1f9-0305-4d0f-8490-78a506a2f8ea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a61a1f9-0305-4d0f-8490-78a506a2f8ea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

