### PR TITLE
Correct Mac desktop shortcut alignment

### DIFF
--- a/apps/www/app/interfaces/desktop-os/scene.css
+++ b/apps/www/app/interfaces/desktop-os/scene.css
@@ -57,7 +57,7 @@
 .dos-mac .dos-window-title span { padding: 2px 6px; background: var(--bg); }
 .dos-mac .dos-window-title > svg { display: none; }
 .dos-mac .dos-menubar > .dos-apps-trigger { font-weight: 600; }
-.dos-mac .dos-shortcut { align-items: flex-start; padding-inline: 12px; text-align: left; }
+.dos-mac .dos-shortcut { align-items: center; }
 .dos-mac .dos-taskbar { display: none; }
 .dos-mac-dockbar { position: relative; z-index: 2; display: flex; justify-content: center; flex: none; padding: 8px 12px 10px; background: var(--table-alt); }
 .dos-mac-dock { display: flex; align-items: center; gap: 2px; max-width: 100%; padding: 4px; border: 1px solid var(--divider); border-radius: 4px; background: var(--bg); }
@@ -120,7 +120,7 @@
 .dos-crop-bar { gap: 14px; padding: 0 12px; font-size: 9px; }
 .dos-crop-bar time { margin-left: auto; }
 .dos-crop-stage { position: relative; flex: 1; background: var(--table-alt); }
-.dos-crop-icons { position: absolute; top: 16px; left: 12px; display: flex; flex-direction: column; align-items: flex-start; gap: 8px; }
+.dos-crop-icons { position: absolute; top: 16px; left: 12px; display: flex; flex-direction: column; align-items: center; gap: 8px; }
 .dos-crop-dock { position: absolute; bottom: 8px; left: 50%; z-index: 1; display: flex; gap: 12px; padding: 8px 12px; border: 1px solid var(--divider); border-radius: 4px; background: var(--bg); transform: translateX(-50%); }
 .dos-crop-window { position: absolute; top: 14px; left: 66px; width: 56%; height: 144px; border: 1px solid var(--divider); background: var(--bg); }
 .dos-crop-title { display: flex; align-items: center; justify-content: space-between; height: 24px; padding: 0 8px; border-bottom: 1px solid var(--divider); background: repeating-linear-gradient(0deg, transparent 0, transparent 3px, var(--divider-subtle) 3px, var(--divider-subtle) 4px); }

--- a/apps/www/scripts/desktop-mac-chrome-e2e.mjs
+++ b/apps/www/scripts/desktop-mac-chrome-e2e.mjs
@@ -6,6 +6,28 @@ const focusReturns = async (page, locator) => {
   await page.waitForFunction(target => document.activeElement === target, element);
   await element.dispose();
 };
+const checkShortcutPlacement = async (desktop, mode) => {
+  const placement = await desktop.locator(".dos-stage").evaluate(stage => {
+    const group = stage.querySelector(".dos-desktop-icons");
+    return {
+      leftOffset: group.getBoundingClientRect().left - stage.getBoundingClientRect().left,
+      icons: [...group.querySelectorAll(".dos-shortcut")].map(element => {
+        const icon = element.querySelector("svg").getBoundingClientRect();
+        const label = element.querySelector("span").getBoundingClientRect();
+        const button = element.getBoundingClientRect();
+        return { iconCenter: icon.left + icon.width / 2, textCenter: label.left + label.width / 2, tileCenter: button.left + button.width / 2, textAlign: getComputedStyle(element).textAlign, width: button.width, height: button.height };
+      }),
+    };
+  });
+  near(placement.leftOffset, 8, `${mode}: shortcut group stays at the desktop's left edge`);
+  assert.ok(placement.icons.length >= 4, "Mac keeps working desktop shortcuts");
+  for (const icon of placement.icons) {
+    near(icon.iconCenter, icon.tileCenter, `${mode}: shortcut icon is centered within its tile`);
+    near(icon.textCenter, icon.tileCenter, `${mode}: shortcut caption is centered within its tile`);
+    assert.equal(icon.textAlign, "center");
+    assert.ok(icon.width >= 44 && icon.height >= 44, "Shortcut retains a full touch target");
+  }
+};
 
 export async function checkDesktopMacChrome({ page, base, fail }) {
   try {
@@ -41,19 +63,7 @@ export async function checkDesktopMacChrome({ page, base, fail }) {
       await desktop.getByRole("dialog").getByRole("button", { name: "Terminal", exact: true }).click();
     } else {
       await dock.waitFor({ state: "visible" });
-      const icons = await desktop.locator(".dos-shortcut").evaluateAll(elements => elements.map(element => {
-        const icon = element.querySelector("svg").getBoundingClientRect();
-        const label = element.querySelector("span").getBoundingClientRect();
-        const button = element.getBoundingClientRect();
-        return { iconLeft: icon.left, textLeft: label.left, textAlign: getComputedStyle(element).textAlign, width: button.width, height: button.height };
-      }));
-      assert.ok(icons.length >= 4, "Mac keeps working desktop shortcuts");
-      for (const icon of icons) {
-        near(icon.iconLeft, icon.textLeft, "Shortcut icon and label share a left origin");
-        near(icon.iconLeft, icons[0].iconLeft, "Desktop shortcuts share a left edge");
-        assert.equal(icon.textAlign, "left");
-        assert.ok(icon.width >= 44 && icon.height >= 44, "Shortcut retains a full touch target");
-      }
+      await checkShortcutPlacement(desktop, "Embedded view");
       assert.equal(await desktop.locator(".dos-taskbar").isVisible(), false, "Desktop Mac uses the dock below its workspace");
       await terminalDock.click();
       assert.equal(await terminalDock.getAttribute("data-running"), "true", "Dock marks a newly launched app as running");
@@ -134,6 +144,7 @@ export async function checkDesktopMacChrome({ page, base, fail }) {
     await page.locator('.if-preview-frame[data-preview-open="true"]').waitFor();
     assert.equal(await terminalInput.inputValue(), "echo Preview keeps this command");
     const previewCompact = await desktop.getAttribute("data-compact") === "true";
+    if (!previewCompact) await checkShortcutPlacement(desktop, "Fullscreen preview");
     const previewMenuTrigger = previewCompact ? systemTrigger : fileTrigger;
     const previewMenu = desktop.getByRole("menu", { name: previewCompact ? "Mac OS" : "File", exact: true });
     await previewMenuTrigger.click();
@@ -159,6 +170,6 @@ export async function checkDesktopMacChrome({ page, base, fail }) {
     }
     await page.getByRole("tab", { name: "Mac OS", exact: true }).click();
     assert.equal(await terminalInput.inputValue(), "echo Preview keeps this command", "OS tab changes retain Mac application state");
-    console.log(`${page.viewportSize().width}px Mac chrome: left-aligned shortcuts, dock or compact tasks, launch/restore, traditional menu keyboard and dismissal, app state and preview preservation`);
+    console.log(`${page.viewportSize().width}px Mac chrome: shortcuts at the desktop's left edge with centered icons and captions, dock or compact tasks, launch/restore, traditional menu keyboard and dismissal, app state and preview preservation`);
   } catch (error) { fail(`Mac desktop chrome: ${error.message}`); }
 }

--- a/docs/desktop-os.md
+++ b/docs/desktop-os.md
@@ -2,7 +2,7 @@
 
 The desktop study at `/interfaces/desktop-os/` adapts four operating-system conventions using Vlak paper, ink, Inter and hairlines. It runs local browser applications, not native operating systems.
 
-- Mac OS follows the creator’s classic Mac prototype: a global menu bar with anchored dropdowns, left-aligned desktop shortcuts, a bottom dock, centered window titles, shading and Finder-style file browsing.
+- Mac OS follows the creator’s classic Mac prototype: a global menu bar with anchored dropdowns, desktop shortcuts along the screen’s left edge, a bottom dock, centered window titles, shading and Finder-style file browsing.
 - Windows follows the creator’s Windows XP prototype: Start, a bottom taskbar, caption controls and independent application windows.
 - Linux uses GNOME conventions: Activities, an application grid, a favorites dock and workspaces.
 - BeOS follows the creator’s BeOS prototype: Deskbar, window title tabs, Tracker and four workspaces.
@@ -19,6 +19,8 @@ Windows can move, resize, minimize, restore, maximize and close. Keyboard users 
 
 ## Mac desktop chrome
 
+Desktop shortcuts form a column at the desktop’s left edge in both the embedded workspace and fullscreen preview. Each icon and caption stays centered within its shortcut tile.
+
 The dock launches applications and restores their existing windows. Running applications have an indicator; the front application also has a selected surface. Maximized windows fill the space above the dock. The Apps control opens the searchable application drawer, and Trash opens its folder in Finder. At workspace widths of 680px or less, the desktop shortcuts and dock are hidden and the bottom Apps and Tasks controls remain available.
 
 Mac OS, File and Window open traditional dropdown menus below the menu bar. File creates documents and opens Documents or Trash. Window provides minimize, zoom, shade, arrangement and individual window switching. Selecting a window restores it with its existing application state.
@@ -33,7 +35,7 @@ Arrow keys move through menu items and between menus; Home and End reach the fir
 
 ## Validation
 
-`desktop-os.test.mjs` checks filesystem integrity, independent records, terminal operations and arithmetic parsing. `desktop-os-e2e.mjs` checks editor-to-terminal-to-file-manager workflows across all four desktops, independent persisted files, window controls, compact application screens, browser navigation and keyboard menu dismissal. `desktop-mac-chrome-e2e.mjs` checks shortcut alignment, dock launch and restore, maximized-window bounds, dropdown placement and keyboard behavior, compact controls, preview state and the other platforms’ launchers. The interface refresh suite checks light and dark appearance, accessibility, overflow and 44px targets at 320, 390, 1024 and 1440px.
+`desktop-os.test.mjs` checks filesystem integrity, independent records, terminal operations and arithmetic parsing. `desktop-os-e2e.mjs` checks editor-to-terminal-to-file-manager workflows across all four desktops, independent persisted files, window controls, compact application screens, browser navigation and keyboard menu dismissal. `desktop-mac-chrome-e2e.mjs` checks shortcut placement and centered captions in embedded and fullscreen views, dock launch and restore, maximized-window bounds, dropdown placement and keyboard behavior, compact controls, preview state and the other platforms’ launchers. The interface refresh suite checks light and dark appearance, accessibility, overflow and 44px targets at 320, 390, 1024 and 1440px.
 
 ## Full-screen preview
 


### PR DESCRIPTION
Correct the Mac shortcut alignment: keep the column at the desktop’s left edge while centering each icon and caption within its tile. The interface-card preview uses the same centered treatment.

Updated the existing placement assertions for both embedded and fullscreen views. Validation: production build, focused Mac desktop checks at 390, 1024 and 1440px, visual fullscreen review and scoped lint passed.
